### PR TITLE
✨ Support mstyle-based sizes and fix style rules (e.g. \displaystyle)

### DIFF
--- a/latex2mathml/commands.py
+++ b/latex2mathml/commands.py
@@ -231,10 +231,22 @@ BIG: Dict[str, Tuple[str, dict]] = {
     r"\big": ("mo", OrderedDict([("minsize", "1.2em"), ("maxsize", "1.2em")])),
 }
 
-HUGE: Dict[str, Tuple[str, dict]] = {
+MSTYLE_SIZES: Dict[str, Tuple[str, dict]] = {
     # command: (mathml_equivalent, attributes)
     r"\Huge": ("mstyle", {"mathsize": "2.49em"}),
     r"\huge": ("mstyle", {"mathsize": "2.07em"}),
+    r"\LARGE": ("mstyle", {"mathsize": "1.73em"}),
+    r"\Large": ("mstyle", {"mathsize": "1.44em"}),
+    r"\large": ("mstyle", {"mathsize": "1.2em"}),
+    r"\normalsize": ("mstyle", {"mathsize": "1em"}),
+    r"\scriptsize": ("mstyle", {"mathsize": "0.7em"}),
+}
+
+STYLES: Dict[str, Tuple[str, dict]] = {
+    DISPLAYSTYLE: ("mstyle", {"displaystyle": "true", "scriptlevel": "0"}),
+    TEXTSTYLE: ("mstyle", {"displaystyle": "false", "scriptlevel": "0"}),
+    SCRIPTSTYLE: ("mstyle", {"displaystyle": "false", "scriptlevel": "1"}),
+    SCRIPTSCRIPTSTYLE: ("mstyle", {"displaystyle": "false", "scriptlevel": "2"}),
 }
 
 CONVERSION_MAP: Dict[str, Tuple[str, dict]] = {
@@ -295,16 +307,13 @@ CONVERSION_MAP: Dict[str, Tuple[str, dict]] = {
     FBOX: ("menclose", {"notation": "box"}),
     # operators
     **BIG,
-    **HUGE,
+    **MSTYLE_SIZES,
     **{limit: ("mo", {}) for limit in LIMIT},
     LEFT: ("mo", OrderedDict([("stretchy", "true"), ("fence", "true"), ("form", "prefix")])),
     RIGHT: ("mo", OrderedDict([("stretchy", "true"), ("fence", "true"), ("form", "postfix")])),
     # styles
     COLOR: ("mstyle", {}),
-    DISPLAYSTYLE: ("mstyle", {"displaystyle": "true", "scriptlevel": "0"}),
-    TEXTSTYLE: ("mstyle", {"displaystyle": "false", "scriptlevel": "0"}),
-    SCRIPTSTYLE: ("mstyle", {"displaystyle": "false", "scriptlevel": "1"}),
-    SCRIPTSCRIPTSTYLE: ("mstyle", {"displaystyle": "false", "scriptlevel": "2"}),
+    **STYLES,
     # others
     SQRT: ("msqrt", {}),
     ROOT: ("mroot", {}),

--- a/latex2mathml/converter.py
+++ b/latex2mathml/converter.py
@@ -121,7 +121,7 @@ def _convert_group(
     _font = font
     for node in nodes:
         token = node.token
-        if token in commands.HUGE:
+        if token in (*commands.MSTYLE_SIZES, *commands.STYLES):
             node = Node(token=token, children=tuple(n for n in nodes))
             _convert_command(node, parent, is_math_mode, _font)
         elif token in commands.CONVERSION_MAP:

--- a/latex2mathml/tokenizer.py
+++ b/latex2mathml/tokenizer.py
@@ -32,6 +32,8 @@ def tokenize(data: str) -> Iterator[str]:
         first_match = match.group(0)
         if first_match.startswith(commands.MATH):
             yield from _tokenize_math(first_match)
+        elif first_match == commands.TEXTSTYLE:
+            yield first_match  # prevent the next line (commands.TEXT)
         elif first_match.startswith((commands.COLOR, commands.FBOX, commands.HREF, commands.TEXT)):
             index = first_match.index(commands.OPENING_BRACE)
             yield first_match[:index].strip()

--- a/latex2mathml/walker.py
+++ b/latex2mathml/walker.py
@@ -122,10 +122,6 @@ def _walk(tokens: Iterator[str], terminator: str = None, limit: int = 0) -> List
             if sibling:
                 group.append(sibling)
             break
-        elif token == commands.DISPLAYSTYLE:
-            children = tuple(_walk(tokens, terminator=terminator))
-            group.extend([Node(token=token, children=children[:-1]), children[-1]])
-            break
         elif token in (*commands.BIG.keys(), commands.TEXT, commands.FBOX):
             node = Node(token=token, text=next(tokens))
         elif token == commands.HREF:
@@ -224,7 +220,8 @@ def _walk(tokens: Iterator[str], terminator: str = None, limit: int = 0) -> List
             attributes = {"linethickness": dimension}
             children = tuple(_walk(tokens, terminator=terminator, limit=2))
             child = Node(token=token, children=children, delimiter=delimiter, attributes=attributes)
-            node = Node(token=style, children=(child,))
+            group.extend([Node(token=style), child])
+            break
         elif token.startswith(commands.BEGIN):
             node = _get_environment_node(token, tokens)
         else:

--- a/latex2mathml/walker.py
+++ b/latex2mathml/walker.py
@@ -219,8 +219,9 @@ def _walk(tokens: Iterator[str], terminator: str = None, limit: int = 0) -> List
             style = _get_style(style_node)
             attributes = {"linethickness": dimension}
             children = tuple(_walk(tokens, terminator=terminator, limit=2))
-            child = Node(token=token, children=children, delimiter=delimiter, attributes=attributes)
-            group.extend([Node(token=style), child])
+            group.extend(
+                [Node(token=style), Node(token=token, children=children, delimiter=delimiter, attributes=attributes)]
+            )
             break
         elif token.startswith(commands.BEGIN):
             node = _get_environment_node(token, tokens)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "latex2mathml"
-version = "3.49.0-alpha.1"
+version = "3.49.0"
 repository = "https://github.com/roniemartinez/latex2mathml"
 description = "Pure Python library for LaTeX to MathML conversion"
 authors = ["Ronie Martinez <ronmarti18@gmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "latex2mathml"
-version = "3.48.0"
+version = "3.49.0-alpha.0"
 repository = "https://github.com/roniemartinez/latex2mathml"
 description = "Pure Python library for LaTeX to MathML conversion"
 authors = ["Ronie Martinez <ronmarti18@gmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "latex2mathml"
-version = "3.49.0-alpha.0"
+version = "3.49.0-alpha.1"
 repository = "https://github.com/roniemartinez/latex2mathml"
 description = "Pure Python library for LaTeX to MathML conversion"
 authors = ["Ronie Martinez <ronmarti18@gmail.com>"]

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if os.path.exists(readme_path):
 setup(
     long_description=readme,
     name='latex2mathml',
-    version='3.49.0-alpha.0',
+    version='3.49.0-alpha.1',
     description='Pure Python library for LaTeX to MathML conversion',
     python_requires='<4,>=3.6.2',
     project_urls={"repository": "https://github.com/roniemartinez/latex2mathml"},

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if os.path.exists(readme_path):
 setup(
     long_description=readme,
     name='latex2mathml',
-    version='3.48.0',
+    version='3.49.0-alpha.0',
     description='Pure Python library for LaTeX to MathML conversion',
     python_requires='<4,>=3.6.2',
     project_urls={"repository": "https://github.com/roniemartinez/latex2mathml"},

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if os.path.exists(readme_path):
 setup(
     long_description=readme,
     name='latex2mathml',
-    version='3.49.0-alpha.1',
+    version='3.49.0',
     description='Pure Python library for LaTeX to MathML conversion',
     python_requires='<4,>=3.6.2',
     project_urls={"repository": "https://github.com/roniemartinez/latex2mathml"},

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -2426,6 +2426,89 @@ from latex2mathml.converter import _convert, convert
         pytest.param(r"\intop", {"mo": {"@movablelimits": "true", "$": "&#x0222B;"}}, id="intop"),
         pytest.param(r"\injlim", {"mo": {"@movablelimits": "true", "$": "inj&#x02006;lim"}}, id="injlim"),
         pytest.param(r"\ker", {"mi": "ker"}, id="ker"),
+        pytest.param(
+            r"[{[\LARGE[\Large[\large[[}[",
+            MultiDict(
+                [
+                    ("mo", {"@stretchy": "false", "$": "["}),
+                    (
+                        "mrow",
+                        MultiDict(
+                            [
+                                ("mo", {"@stretchy": "false", "$": "["}),
+                                (
+                                    "mstyle",
+                                    MultiDict(
+                                        [
+                                            ("@mathsize", "1.73em"),
+                                            ("mo", {"@stretchy": "false", "$": "["}),
+                                            (
+                                                "mstyle",
+                                                MultiDict(
+                                                    [
+                                                        ("@mathsize", "1.44em"),
+                                                        ("mo", {"@stretchy": "false", "$": "["}),
+                                                        (
+                                                            "mstyle",
+                                                            MultiDict(
+                                                                [
+                                                                    ("@mathsize", "1.2em"),
+                                                                    ("mo", {"@stretchy": "false", "$": "["}),
+                                                                    ("mo", {"@stretchy": "false", "$": "["}),
+                                                                ]
+                                                            ),
+                                                        ),
+                                                    ]
+                                                ),
+                                            ),
+                                        ]
+                                    ),
+                                ),
+                            ]
+                        ),
+                    ),
+                    ("mo", {"@stretchy": "false", "$": "["}),
+                ]
+            ),
+            id="large",
+        ),
+        pytest.param(
+            r"[{[\normalsize[\scriptsize[[}[",
+            MultiDict(
+                [
+                    ("mo", {"@stretchy": "false", "$": "["}),
+                    (
+                        "mrow",
+                        MultiDict(
+                            [
+                                ("mo", {"@stretchy": "false", "$": "["}),
+                                (
+                                    "mstyle",
+                                    MultiDict(
+                                        [
+                                            ("@mathsize", "1em"),
+                                            ("mo", {"@stretchy": "false", "$": "["}),
+                                            (
+                                                "mstyle",
+                                                MultiDict(
+                                                    [
+                                                        ("@mathsize", "0.7em"),
+                                                        ("mo", {"@stretchy": "false", "$": "["}),
+                                                        ("mo", {"@stretchy": "false", "$": "["}),
+                                                    ]
+                                                ),
+                                            ),
+                                        ]
+                                    ),
+                                ),
+                            ]
+                        ),
+                    ),
+                    ("mo", {"@stretchy": "false", "$": "["}),
+                ]
+            ),
+            id="normalsize-scriptsize",
+        ),
     ],
 )
 def test_converter(latex: str, json: MultiDict) -> None:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -2047,6 +2047,59 @@ from latex2mathml.converter import _convert, convert
             id="displaystyle",
         ),
         pytest.param(
+            r"\frac ab+\displaystyle\frac cd+\textstyle\frac ef+\scriptstyle\frac gh+\scriptscriptstyle\frac ij",
+            MultiDict(
+                [
+                    ("mfrac", MultiDict([("mi", "a"), ("mi", "b")])),
+                    ("mo", "&#x0002B;"),
+                    (
+                        "mstyle",
+                        MultiDict(
+                            [
+                                ("@displaystyle", "true"),
+                                ("@scriptlevel", "0"),
+                                ("mfrac", MultiDict([("mi", "c"), ("mi", "d")])),
+                                ("mo", "&#x0002B;"),
+                                (
+                                    "mstyle",
+                                    MultiDict(
+                                        [
+                                            ("@displaystyle", "false"),
+                                            ("@scriptlevel", "0"),
+                                            ("mfrac", MultiDict([("mi", "e"), ("mi", "f")])),
+                                            ("mo", "&#x0002B;"),
+                                            (
+                                                "mstyle",
+                                                MultiDict(
+                                                    [
+                                                        ("@displaystyle", "false"),
+                                                        ("@scriptlevel", "1"),
+                                                        ("mfrac", MultiDict([("mi", "g"), ("mi", "h")])),
+                                                        ("mo", "&#x0002B;"),
+                                                        (
+                                                            "mstyle",
+                                                            MultiDict(
+                                                                [
+                                                                    ("@displaystyle", "false"),
+                                                                    ("@scriptlevel", "2"),
+                                                                    ("mfrac", MultiDict([("mi", "i"), ("mi", "j")])),
+                                                                ]
+                                                            ),
+                                                        ),
+                                                    ]
+                                                ),
+                                            ),
+                                        ]
+                                    ),
+                                ),
+                            ]
+                        ),
+                    ),
+                ]
+            ),
+            id="styles",
+        ),
+        pytest.param(
             r"""
             \displaylines{
                 a = a\cr


### PR DESCRIPTION
- \LARGE
- \Large
- \large
- \normalsize
- \scriptsize
- 🐛 Fix \displaystyle, \textstyle, \scriptstyle and \scriptscriptstyle