### PR TITLE
✨ Suppor more diacritics

### DIFF
--- a/latex2mathml/commands.py
+++ b/latex2mathml/commands.py
@@ -60,6 +60,7 @@ OVERLEFTRIGHTARROW = r"\overleftrightarrow"
 OVERLINE = r"\overline"
 OVERPAREN = r"\overparen"
 OVERRIGHTARROW = r"\overrightarrow"
+TILDE = r"\tilde"
 UNDERLEFTARROW = r"\underleftarrow"
 UNDERLINE = r"\underline"
 UNDERPAREN = r"\underparen"
@@ -252,6 +253,7 @@ COMMANDS_WITH_ONE_PARAMETER = (
     OVERLINE,
     OVERPAREN,
     OVERRIGHTARROW,
+    TILDE,
     UNDERLEFTARROW,
     UNDERLINE,
     UNDERPAREN,
@@ -334,6 +336,7 @@ CONVERSION_MAP: Dict[str, Tuple[str, dict]] = {
     OVERLINE: ("mover", {}),
     OVERPAREN: ("mover", {}),
     OVERRIGHTARROW: ("mover", {}),
+    TILDE: ("mover", {}),
     OVERSET: ("mover", {}),
     UNDERLEFTARROW: ("munder", {}),
     UNDERLINE: ("munder", {}),
@@ -404,6 +407,7 @@ DIACRITICS: Dict[str, Tuple[str, Dict[str, str]]] = {
     OVERLINE: ("&#x02015;", {"accent": "true"}),
     OVERPAREN: ("&#x023DC;", {}),
     OVERRIGHTARROW: ("&#x02192;", {}),
+    TILDE: ("&#x0007E;", {"stretchy": "false"}),
     UNDERLEFTARROW: ("&#x02190;", {}),
     UNDERLEFTRIGHTARROW: ("&#x02194;", {}),
     UNDERLINE: ("&#x02015;", {"accent": "true"}),

--- a/latex2mathml/commands.py
+++ b/latex2mathml/commands.py
@@ -54,10 +54,20 @@ DDDOT = r"\dddot"
 DDDDOT = r"\ddddot"
 GRAVE = r"\grave"
 HAT = r"\hat"
+MATHRING = r"\mathring"
+OVERLEFTARROW = r"\overleftarrow"
+OVERLEFTRIGHTARROW = r"\overleftrightarrow"
 OVERLINE = r"\overline"
+OVERPAREN = r"\overparen"
 OVERRIGHTARROW = r"\overrightarrow"
+UNDERLEFTARROW = r"\underleftarrow"
 UNDERLINE = r"\underline"
+UNDERPAREN = r"\underparen"
+UNDERRIGHTARROW = r"\underrightarrow"
+UNDERLEFTRIGHTARROW = r"\underleftrightarrow"
 VEC = r"\vec"
+WIDEHAT = r"\widehat"
+WIDETILDE = r"\widetilde"
 
 HREF = r"\href"
 TEXT = r"\text"
@@ -236,10 +246,20 @@ COMMANDS_WITH_ONE_PARAMETER = (
     GRAVE,
     HAT,
     HPHANTOM,
+    MATHRING,
+    OVERLEFTARROW,
+    OVERLEFTRIGHTARROW,
     OVERLINE,
+    OVERPAREN,
     OVERRIGHTARROW,
+    UNDERLEFTARROW,
     UNDERLINE,
+    UNDERPAREN,
+    UNDERRIGHTARROW,
+    UNDERLEFTRIGHTARROW,
     VEC,
+    WIDEHAT,
+    WIDETILDE,
 )
 COMMANDS_WITH_TWO_PARAMETERS = (
     BINOM,
@@ -308,12 +328,22 @@ CONVERSION_MAP: Dict[str, Tuple[str, dict]] = {
     GRAVE: ("mover", {}),
     HAT: ("mover", {}),
     LIMITS: ("munderover", {}),
+    MATHRING: ("mover", {}),
+    OVERLEFTARROW: ("mover", {}),
+    OVERLEFTRIGHTARROW: ("mover", {}),
     OVERLINE: ("mover", {}),
+    OVERPAREN: ("mover", {}),
     OVERRIGHTARROW: ("mover", {}),
     OVERSET: ("mover", {}),
+    UNDERLEFTARROW: ("munder", {}),
     UNDERLINE: ("munder", {}),
+    UNDERPAREN: ("munder", {}),
+    UNDERRIGHTARROW: ("munder", {}),
+    UNDERLEFTRIGHTARROW: ("munder", {}),
     UNDERSET: ("munder", {}),
     VEC: ("mover", {}),
+    WIDEHAT: ("mover", {}),
+    WIDETILDE: ("mover", {}),
     # spaces
     COLON: ("mspace", {"width": "0.222em"}),
     COMMA: ("mspace", {"width": "0.167em"}),
@@ -356,13 +386,10 @@ CONVERSION_MAP: Dict[str, Tuple[str, dict]] = {
     HPHANTOM: ("mphantom", {}),
 }
 
+
 DIACRITICS: Dict[str, Tuple[str, Dict[str, str]]] = {
-    OVERLINE: ("&#x000AF;", {"stretchy": "true"}),
-    BAR: ("&#x000AF;", {"stretchy": "true"}),
-    UNDERLINE: ("&#x00332;", {"stretchy": "true"}),
-    OVERRIGHTARROW: ("&#x02192;", {"stretchy": "true"}),
-    VEC: ("&#x02192;", {"stretchy": "true"}),
     ACUTE: ("&#x000B4;", {}),
+    BAR: ("&#x000AF;", {"stretchy": "true"}),
     BREVE: ("&#x002D8;", {}),
     CHECK: ("&#x002C7;", {}),
     DOT: ("&#x002D9;", {}),
@@ -371,4 +398,18 @@ DIACRITICS: Dict[str, Tuple[str, Dict[str, str]]] = {
     DDDDOT: ("&#x020DC;", {}),
     GRAVE: ("&#x00060;", {}),
     HAT: ("&#x0005E;", {}),
+    MATHRING: ("&#x002DA;", {}),
+    OVERLEFTARROW: ("&#x02190;", {}),
+    OVERLEFTRIGHTARROW: ("&#x02194;", {}),
+    OVERLINE: ("&#x02015;", {"accent": "true"}),
+    OVERPAREN: ("&#x023DC;", {}),
+    OVERRIGHTARROW: ("&#x02192;", {}),
+    UNDERLEFTARROW: ("&#x02190;", {}),
+    UNDERLEFTRIGHTARROW: ("&#x02194;", {}),
+    UNDERLINE: ("&#x02015;", {"accent": "true"}),
+    UNDERPAREN: ("&#x023DD;", {}),
+    UNDERRIGHTARROW: ("&#x02192;", {}),
+    VEC: ("&#x02192;", {"stretchy": "true"}),
+    WIDEHAT: ("&#x0005E;", {}),
+    WIDETILDE: ("&#x0007E;", {}),
 }

--- a/latex2mathml/symbols_parser.py
+++ b/latex2mathml/symbols_parser.py
@@ -74,4 +74,5 @@ def parse_symbols() -> Dict[str, str]:
             r"\varsupsetneqq": _symbols[r"\supsetneqq"],
         }
     )
+    del _symbols[r"\mathring"]  # FIXME: improve tokenizer without removing this
     return _symbols

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "latex2mathml"
-version = "3.54.0"
+version = "3.55.0"
 repository = "https://github.com/roniemartinez/latex2mathml"
 description = "Pure Python library for LaTeX to MathML conversion"
 authors = ["Ronie Martinez <ronmarti18@gmail.com>"]

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if os.path.exists(readme_path):
 setup(
     long_description=readme,
     name='latex2mathml',
-    version='3.54.0',
+    version='3.55.0',
     description='Pure Python library for LaTeX to MathML conversion',
     python_requires='<4,>=3.6.2',
     project_urls={"repository": "https://github.com/roniemartinez/latex2mathml"},
@@ -38,5 +38,5 @@ setup(
     package_dir={"": "."},
     package_data={"latex2mathml": ["*.txt"]},
     install_requires=[],
-    extras_require={"dev": ["autoflake==1.*,>=1.3.1", "black==21.*,>=21.6.0.b0", "codecov==2.*,>=2.0.16", "dephell==0.*,>=0.8.3", "flake8==3.*,>=3.7.9", "isort==5.*,>=5.4.2", "multidict==5.*,>=5.1.0", "mypy==0.*,>=0.902.0", "pyproject-flake8==0.*,>=0.0.1.a2", "pytest==6.*,>=6.0.1", "pytest-cov==2.*,>=2.8.1", "tomlkit==0.7.0", "xmljson==0.*,>=0.2.0"]},
+    extras_require={"dev": ["autoflake==1.*,>=1.3.1", "black==21.*,>=21.6.0.b0", "codecov==2.*,>=2.0.16", "dephell==0.*,>=0.8.3", "flake8==3.*,>=3.7.9", "isort==5.*,>=5.9.1", "multidict==5.*,>=5.1.0", "mypy==0.*,>=0.902.0", "pyproject-flake8==0.*,>=0.0.1.a2", "pytest==6.*,>=6.0.1", "pytest-cov==2.*,>=2.8.1", "tomlkit==0.7.0", "xmljson==0.*,>=0.2.0"]},
 )

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -203,16 +203,6 @@ from latex2mathml.converter import _convert, convert
         ),
         pytest.param(r"\,", {"mspace": {"@width": "0.167em"}}, id="space"),
         pytest.param(
-            r"\overline{a}",
-            {"mover": MultiDict([("mrow", {"mi": "a"}), ("mo", {"@stretchy": "true", "$": "&#x000AF;"})])},
-            id="overline",
-        ),
-        pytest.param(
-            r"\underline{a}",
-            {"munder": MultiDict([("mrow", {"mi": "a"}), ("mo", {"@stretchy": "true", "$": "&#x00332;"})])},
-            id="underline",
-        ),
-        pytest.param(
             r"\begin{matrix}a & b \\ c & d \end{matrix}",
             {
                 "mtable": MultiDict(
@@ -1109,11 +1099,6 @@ from latex2mathml.converter import _convert, convert
             id="issue-91",
         ),
         pytest.param(r"p_{\max}", {"msub": MultiDict([("mi", "p"), ("mrow", {"mo": "max"})])}, id="issue-98"),
-        pytest.param(
-            r"\overrightarrow {a}",
-            {"mover": MultiDict([("mrow", {"mi": "a"}), ("mo", {"@stretchy": "true", "$": "&#x02192;"})])},
-            id="issue-100",
-        ),
         pytest.param(
             r"\vec{AB}",
             {
@@ -3013,6 +2998,383 @@ from latex2mathml.converter import _convert, convert
                 )
             },
             id="style",
+        ),
+        pytest.param(
+            r"\mathring a \mathring{bc}",
+            MultiDict(
+                [
+                    (
+                        "mover",
+                        MultiDict([("mi", "a"), ("mo", "&#x002DA;")]),
+                    ),
+                    (
+                        "mover",
+                        MultiDict(
+                            [
+                                (
+                                    "mrow",
+                                    MultiDict(
+                                        [
+                                            ("mi", "b"),
+                                            ("mi", "c"),
+                                        ]
+                                    ),
+                                ),
+                                ("mo", "&#x002DA;"),
+                            ]
+                        ),
+                    ),
+                ]
+            ),
+            id="mathring",
+        ),
+        pytest.param(
+            r"\overleftarrow a \overleftarrow{bc}",
+            MultiDict(
+                [
+                    (
+                        "mover",
+                        MultiDict([("mi", "a"), ("mo", "&#x02190;")]),
+                    ),
+                    (
+                        "mover",
+                        MultiDict(
+                            [
+                                (
+                                    "mrow",
+                                    MultiDict(
+                                        [
+                                            ("mi", "b"),
+                                            ("mi", "c"),
+                                        ]
+                                    ),
+                                ),
+                                ("mo", "&#x02190;"),
+                            ]
+                        ),
+                    ),
+                ]
+            ),
+            id="overleftarrow",
+        ),
+        pytest.param(
+            r"\overleftrightarrow a \overleftrightarrow{bc}",
+            MultiDict(
+                [
+                    (
+                        "mover",
+                        MultiDict([("mi", "a"), ("mo", "&#x02194;")]),
+                    ),
+                    (
+                        "mover",
+                        MultiDict(
+                            [
+                                (
+                                    "mrow",
+                                    MultiDict(
+                                        [
+                                            ("mi", "b"),
+                                            ("mi", "c"),
+                                        ]
+                                    ),
+                                ),
+                                ("mo", "&#x02194;"),
+                            ]
+                        ),
+                    ),
+                ]
+            ),
+            id="overleftrightarrow",
+        ),
+        pytest.param(
+            r"\overline a \overline{bc}",
+            MultiDict(
+                [
+                    (
+                        "mover",
+                        MultiDict([("mi", "a"), ("mo", {"@accent": "true", "$": "&#x02015;"})]),
+                    ),
+                    (
+                        "mover",
+                        MultiDict(
+                            [
+                                (
+                                    "mrow",
+                                    MultiDict(
+                                        [
+                                            ("mi", "b"),
+                                            ("mi", "c"),
+                                        ]
+                                    ),
+                                ),
+                                ("mo", {"@accent": "true", "$": "&#x02015;"}),
+                            ]
+                        ),
+                    ),
+                ]
+            ),
+            id="overline",
+        ),
+        pytest.param(
+            r"\overparen a \overparen{bc}",
+            MultiDict(
+                [
+                    (
+                        "mover",
+                        MultiDict([("mi", "a"), ("mo", "&#x023DC;")]),
+                    ),
+                    (
+                        "mover",
+                        MultiDict(
+                            [
+                                (
+                                    "mrow",
+                                    MultiDict(
+                                        [
+                                            ("mi", "b"),
+                                            ("mi", "c"),
+                                        ]
+                                    ),
+                                ),
+                                ("mo", "&#x023DC;"),
+                            ]
+                        ),
+                    ),
+                ]
+            ),
+            id="overparen",
+        ),
+        pytest.param(
+            r"\overrightarrow a \overrightarrow{bc}",
+            MultiDict(
+                [
+                    (
+                        "mover",
+                        MultiDict([("mi", "a"), ("mo", "&#x02192;")]),
+                    ),
+                    (
+                        "mover",
+                        MultiDict(
+                            [
+                                (
+                                    "mrow",
+                                    MultiDict(
+                                        [
+                                            ("mi", "b"),
+                                            ("mi", "c"),
+                                        ]
+                                    ),
+                                ),
+                                ("mo", "&#x02192;"),
+                            ]
+                        ),
+                    ),
+                ]
+            ),
+            id="overrightarrow",
+        ),
+        pytest.param(
+            r"\underleftarrow a \underleftarrow{bc}",
+            MultiDict(
+                [
+                    (
+                        "munder",
+                        MultiDict([("mi", "a"), ("mo", "&#x02190;")]),
+                    ),
+                    (
+                        "munder",
+                        MultiDict(
+                            [
+                                (
+                                    "mrow",
+                                    MultiDict(
+                                        [
+                                            ("mi", "b"),
+                                            ("mi", "c"),
+                                        ]
+                                    ),
+                                ),
+                                ("mo", "&#x02190;"),
+                            ]
+                        ),
+                    ),
+                ]
+            ),
+            id="underleftarrow",
+        ),
+        pytest.param(
+            r"\underrightarrow a \underrightarrow{bc}",
+            MultiDict(
+                [
+                    (
+                        "munder",
+                        MultiDict([("mi", "a"), ("mo", "&#x02192;")]),
+                    ),
+                    (
+                        "munder",
+                        MultiDict(
+                            [
+                                (
+                                    "mrow",
+                                    MultiDict(
+                                        [
+                                            ("mi", "b"),
+                                            ("mi", "c"),
+                                        ]
+                                    ),
+                                ),
+                                ("mo", "&#x02192;"),
+                            ]
+                        ),
+                    ),
+                ]
+            ),
+            id="underrightarrow",
+        ),
+        pytest.param(
+            r"\underleftrightarrow a \underleftrightarrow{bc}",
+            MultiDict(
+                [
+                    (
+                        "munder",
+                        MultiDict([("mi", "a"), ("mo", "&#x02194;")]),
+                    ),
+                    (
+                        "munder",
+                        MultiDict(
+                            [
+                                (
+                                    "mrow",
+                                    MultiDict(
+                                        [
+                                            ("mi", "b"),
+                                            ("mi", "c"),
+                                        ]
+                                    ),
+                                ),
+                                ("mo", "&#x02194;"),
+                            ]
+                        ),
+                    ),
+                ]
+            ),
+            id="underleftrightarrow",
+        ),
+        pytest.param(
+            r"\underline a \underline{bc}",
+            MultiDict(
+                [
+                    (
+                        "munder",
+                        MultiDict([("mi", "a"), ("mo", {"@accent": "true", "$": "&#x02015;"})]),
+                    ),
+                    (
+                        "munder",
+                        MultiDict(
+                            [
+                                (
+                                    "mrow",
+                                    MultiDict(
+                                        [
+                                            ("mi", "b"),
+                                            ("mi", "c"),
+                                        ]
+                                    ),
+                                ),
+                                ("mo", {"@accent": "true", "$": "&#x02015;"}),
+                            ]
+                        ),
+                    ),
+                ]
+            ),
+            id="underline",
+        ),
+        pytest.param(
+            r"\underparen a \underparen{bc}",
+            MultiDict(
+                [
+                    (
+                        "munder",
+                        MultiDict([("mi", "a"), ("mo", "&#x023DD;")]),
+                    ),
+                    (
+                        "munder",
+                        MultiDict(
+                            [
+                                (
+                                    "mrow",
+                                    MultiDict(
+                                        [
+                                            ("mi", "b"),
+                                            ("mi", "c"),
+                                        ]
+                                    ),
+                                ),
+                                ("mo", "&#x023DD;"),
+                            ]
+                        ),
+                    ),
+                ]
+            ),
+            id="underparen",
+        ),
+        pytest.param(
+            r"\widehat a \widehat{bc}",
+            MultiDict(
+                [
+                    (
+                        "mover",
+                        MultiDict([("mi", "a"), ("mo", "&#x0005E;")]),
+                    ),
+                    (
+                        "mover",
+                        MultiDict(
+                            [
+                                (
+                                    "mrow",
+                                    MultiDict(
+                                        [
+                                            ("mi", "b"),
+                                            ("mi", "c"),
+                                        ]
+                                    ),
+                                ),
+                                ("mo", "&#x0005E;"),
+                            ]
+                        ),
+                    ),
+                ]
+            ),
+            id="widehat",
+        ),
+        pytest.param(
+            r"\widetilde a \widetilde{bc}",
+            MultiDict(
+                [
+                    (
+                        "mover",
+                        MultiDict([("mi", "a"), ("mo", "&#x0007E;")]),
+                    ),
+                    (
+                        "mover",
+                        MultiDict(
+                            [
+                                (
+                                    "mrow",
+                                    MultiDict(
+                                        [
+                                            ("mi", "b"),
+                                            ("mi", "c"),
+                                        ]
+                                    ),
+                                ),
+                                ("mo", "&#x0007E;"),
+                            ]
+                        ),
+                    ),
+                ]
+            ),
+            id="widetilde",
         ),
     ],
 )

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -3174,6 +3174,35 @@ from latex2mathml.converter import _convert, convert
             id="overrightarrow",
         ),
         pytest.param(
+            r"\tilde a \tilde{bc}",
+            MultiDict(
+                [
+                    (
+                        "mover",
+                        MultiDict([("mi", "a"), ("mo", {"@stretchy": "false", "$": "&#x0007E;"})]),
+                    ),
+                    (
+                        "mover",
+                        MultiDict(
+                            [
+                                (
+                                    "mrow",
+                                    MultiDict(
+                                        [
+                                            ("mi", "b"),
+                                            ("mi", "c"),
+                                        ]
+                                    ),
+                                ),
+                                ("mo", {"@stretchy": "false", "$": "&#x0007E;"}),
+                            ]
+                        ),
+                    ),
+                ]
+            ),
+            id="tilde",
+        ),
+        pytest.param(
             r"\underleftarrow a \underleftarrow{bc}",
             MultiDict(
                 [


### PR DESCRIPTION
- \mathring
- \overleftarrow
- \overleftrightarrow
- \overparen
- \tilde
- \underleftarrow
- \underparen
- \underrightarrow
- \underleftrightarrow
- \widehat
- \widetilde
- Fix \overline and \underline
- Resolves #202 
- Related to #161 