### PR TITLE
Add option to read TeX input from STDIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ mathml_output = latex2mathml.converter.convert(latex_input)
 
 ```shell
 % latex2mathml -h
-usage: latex2mathml [-h] [-V] [-b] [-t TEXT | -f FILE]
+usage: latex2mathml [-h] [-V] [-b] [-t TEXT | -f FILE | -s]
 
 Pure Python library for LaTeX to MathML conversion
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -V, --version         Show version
   -b, --block           Display block
@@ -66,6 +66,7 @@ optional arguments:
 required arguments:
   -t TEXT, --text TEXT  Text
   -f FILE, --file FILE  File
+  -s, --stdin           Stdin
 ```
 
 ## References

--- a/README.rst
+++ b/README.rst
@@ -65,11 +65,11 @@ Command-line
 .. code-block:: shell
 
    % latex2mathml -h
-   usage: latex2mathml [-h] [-V] [-b] [-t TEXT | -f FILE]
+   usage: latex2mathml [-h] [-V] [-b] [-t TEXT | -f FILE | -s]
 
    Pure Python library for LaTeX to MathML conversion
 
-   optional arguments:
+   options:
      -h, --help            show this help message and exit
      -V, --version         Show version
      -b, --block           Display block
@@ -77,6 +77,7 @@ Command-line
    required arguments:
      -t TEXT, --text TEXT  Text
      -f FILE, --file FILE  File
+     -s, --stdin           Stdin
 
 References
 ----------

--- a/latex2mathml/converter.py
+++ b/latex2mathml/converter.py
@@ -544,10 +544,9 @@ def _set_font(element: Element, key: str, font: Optional[Dict[str, Optional[str]
 
 def main() -> None:  # pragma: no cover
     import argparse
+    import sys
 
     import pkg_resources
-
-    import sys
 
     parser = argparse.ArgumentParser(description="Pure Python library for LaTeX to MathML conversion")
     parser.add_argument("-V", "--version", dest="version", action="store_true", required=False, help="Show version")
@@ -558,7 +557,7 @@ def main() -> None:  # pragma: no cover
     group = required.add_mutually_exclusive_group(required=False)
     group.add_argument("-t", "--text", dest="text", type=str, required=False, help="Text")
     group.add_argument("-f", "--file", dest="file", type=str, required=False, help="File")
-    group.add_argument("-s", "--stdin", dest="stdin", action='store_true', required=False, help="Stdin")
+    group.add_argument("-s", "--stdin", dest="stdin", action="store_true", required=False, help="Stdin")
 
     arguments = parser.parse_args()
     display = "block" if arguments.block else "inline"

--- a/latex2mathml/converter.py
+++ b/latex2mathml/converter.py
@@ -547,6 +547,8 @@ def main() -> None:  # pragma: no cover
 
     import pkg_resources
 
+    import sys
+
     parser = argparse.ArgumentParser(description="Pure Python library for LaTeX to MathML conversion")
     parser.add_argument("-V", "--version", dest="version", action="store_true", required=False, help="Show version")
     parser.add_argument("-b", "--block", dest="block", action="store_true", required=False, help="Display block")
@@ -556,6 +558,7 @@ def main() -> None:  # pragma: no cover
     group = required.add_mutually_exclusive_group(required=False)
     group.add_argument("-t", "--text", dest="text", type=str, required=False, help="Text")
     group.add_argument("-f", "--file", dest="file", type=str, required=False, help="File")
+    group.add_argument("-s", "--stdin", dest="stdin", action='store_true', required=False, help="Stdin")
 
     arguments = parser.parse_args()
     display = "block" if arguments.block else "inline"
@@ -568,6 +571,8 @@ def main() -> None:  # pragma: no cover
     elif arguments.file:
         with open(arguments.file) as f:
             print(convert(f.read(), display=display))
+    elif arguments.stdin:
+        print(convert(sys.stdin.read(), display=display))
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
I added a command line option to read the input from STDIN rather than from a file or string, which makes this easier to use as part of some pipelines and to call as a subprocess.