### PR TITLE
Stretch cases' fence vertically

### DIFF
--- a/latex2mathml/converter.py
+++ b/latex2mathml/converter.py
@@ -230,6 +230,7 @@ def _convert_command(node: Node, parent: Element, font: Optional[Dict[str, Optio
     if command in (commands.SUBSTACK, commands.SMALLMATRIX):
         parent = SubElement(parent, "mstyle", scriptlevel="1")
     elif command == commands.CASES:
+        parent = SubElement(parent, "mrow")
         lbrace = SubElement(parent, "mo", OrderedDict([("stretchy", "true"), ("fence", "true"), ("form", "prefix")]))
         lbrace.text = "&#x{};".format(convert_symbol(commands.LBRACE))
     elif command in (commands.DBINOM, commands.DFRAC):

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1125,50 +1125,55 @@ from latex2mathml.converter import _convert, convert
         ),
         pytest.param(
             r"\begin{cases} {x=1} \\ {y=-2}\end{cases}",
-            MultiDict(
-                [
-                    ("mo", {"@stretchy": "true", "@fence": "true", "@form": "prefix", "$": "&#x0007B;"}),
-                    (
-                        "mtable",
-                        MultiDict(
-                            [
-                                (
-                                    "mtr",
-                                    {
-                                        "mtd": MultiDict(
-                                            [
-                                                ("@columnalign", "left"),
-                                                ("mrow", MultiDict([("mi", "x"), ("mo", "&#x0003D;"), ("mn", "1")])),
-                                            ]
-                                        )
-                                    },
-                                ),
-                                (
-                                    "mtr",
-                                    {
-                                        "mtd": MultiDict(
-                                            [
-                                                ("@columnalign", "left"),
-                                                (
-                                                    "mrow",
-                                                    MultiDict(
-                                                        [
-                                                            ("mi", "y"),
-                                                            ("mo", "&#x0003D;"),
-                                                            ("mo", "&#x02212;"),
-                                                            ("mn", "2"),
-                                                        ]
+            {
+                "mrow": MultiDict(
+                    [
+                        ("mo", {"@stretchy": "true", "@fence": "true", "@form": "prefix", "$": "&#x0007B;"}),
+                        (
+                            "mtable",
+                            MultiDict(
+                                [
+                                    (
+                                        "mtr",
+                                        {
+                                            "mtd": MultiDict(
+                                                [
+                                                    ("@columnalign", "left"),
+                                                    (
+                                                        "mrow",
+                                                        MultiDict([("mi", "x"), ("mo", "&#x0003D;"), ("mn", "1")]),
                                                     ),
-                                                ),
-                                            ]
-                                        )
-                                    },
-                                ),
-                            ]
+                                                ]
+                                            )
+                                        },
+                                    ),
+                                    (
+                                        "mtr",
+                                        {
+                                            "mtd": MultiDict(
+                                                [
+                                                    ("@columnalign", "left"),
+                                                    (
+                                                        "mrow",
+                                                        MultiDict(
+                                                            [
+                                                                ("mi", "y"),
+                                                                ("mo", "&#x0003D;"),
+                                                                ("mo", "&#x02212;"),
+                                                                ("mn", "2"),
+                                                            ]
+                                                        ),
+                                                    ),
+                                                ]
+                                            )
+                                        },
+                                    ),
+                                ]
+                            ),
                         ),
-                    ),
-                ]
-            ),
+                    ]
+                )
+            },
             id="issue-106",
         ),
         pytest.param(r"\max f", MultiDict([("mo", "max"), ("mi", "f")]), id="issue-108-1"),


### PR DESCRIPTION
https://w3c.github.io/mathml-core does not define any observable behavior that is specific to the fence attribute, thus a mrow parent is needed to stretch the brace vertically.

Relevant: GH-296, but (also) affecting browsers.