### PR TITLE
🐛 Fix spaces in \begin, \end and \operatorname

### DIFF
--- a/latex2mathml/tokenizer.py
+++ b/latex2mathml/tokenizer.py
@@ -8,20 +8,21 @@ UNITS = ("in", "mm", "cm", "pt", "em", "ex", "pc", "bp", "dd", "cc", "sp", "mu")
 
 PATTERN = re.compile(
     rf"""
-    (%[^\n]+) |                                         # comment
-    (a-zA-Z) |                                          # letter
-    ([_^])(\d) |                                        # number succeeding an underscore or a caret
-    (-?\d+(?:\.\d+)?\s*(?:{'|'.join(UNITS)})) |         # dimension
-    (\d+(?:\.\d+)?) |                                   # integer/decimal
-    (\.\d*) |                                           # dot (.) or decimal can start with just a dot
-    (\\[\\\[\]{{}}\s!,:>;|_%#$&]) |                     # escaped characters
-    (\\(?:begin|end|operatorname){{[a-zA-Z]+\*?}}) |    # begin, end or operatorname
+    (%[^\n]+) |                                 # comment
+    (a-zA-Z) |                                  # letter
+    ([_^])(\d) |                                # number succeeding an underscore or a caret
+    (-?\d+(?:\.\d+)?\s*(?:{'|'.join(UNITS)})) | # dimension
+    (\d+(?:\.\d+)?) |                           # integer/decimal
+    (\.\d*) |                                   # dot (.) or decimal can start with just a dot
+    (\\[\\\[\]{{}}\s!,:>;|_%#$&]) |             # escaped characters
+    (\\(?:begin|end)\s*{{[a-zA-Z]+\*?}}) |      # begin or end
+    (\\operatorname\s*{{[a-zA-Z\s*]+\*?\s*}}) | # operatorname
     #  color, fbox, href, hbox, mbox, style, text, textbf, textit, textrm, textsf, texttt
     (\\(?:color|fbox|hbox|href|mbox|style|text|textbf|textit|textrm|textsf|texttt))\s*{{([^}}]*)}} |
-    (\\[cdt]?frac)\s*([.\d])\s*([.\d])? |               # fractions
-    (\\math[a-z]+)({{)([a-zA-Z])(}}) |                  # commands starting with math
-    (\\[a-zA-Z]+) |                                     # other commands
-    (\S)                                                # non-space character
+    (\\[cdt]?frac)\s*([.\d])\s*([.\d])? |       # fractions
+    (\\math[a-z]+)({{)([a-zA-Z])(}}) |          # commands starting with math
+    (\\[a-zA-Z]+) |                             # other commands
+    (\S)                                        # non-space character
     """,
     re.VERBOSE,
 )
@@ -47,5 +48,8 @@ def tokenize(latex_string: str, skip_comments: bool = True) -> Iterator[str]:
                 break
             if captured.endswith(UNITS):
                 yield captured.replace(" ", "")
+                continue
+            if captured.startswith((commands.BEGIN, commands.END, commands.OPERATORNAME)):
+                yield "".join(captured.split(" "))
                 continue
             yield captured

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "latex2mathml"
-version = "3.75.3"
+version = "3.75.4"
 repository = "https://github.com/roniemartinez/latex2mathml"
 description = "Pure Python library for LaTeX to MathML conversion"
 authors = ["Ronie Martinez <ronmarti18@gmail.com>"]

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -518,6 +518,8 @@ from latex2mathml.tokenizer import tokenize
         pytest.param(
             r"\frac 1 2 3 + \frac 123", [r"\frac", "1", "2", "3", "+", r"\frac", "1", "2", "3"], id="issue-386"
         ),
+        pytest.param(r"\begin {cases} \end {cases}", [r"\begin{cases}", r"\end{cases}"], id="issue-391"),
+        pytest.param(r"\operatorname { s n } x", [r"\operatorname{sn}", "x"], id="issue-391-operatorname"),
     ],
 )
 def test_tokenize(latex: str, expected: list) -> None:


### PR DESCRIPTION
Fixes #391