### PR TITLE
Remove redundant mypy overrides

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,9 +72,6 @@ extend-exclude = """
 disallow_untyped_defs = true
 ignore_missing_imports = true
 
-[[tool.mypy.overrides]]
-ignore_missing_imports = true
-
 [tool.flake8]
 max-line-length = 120
 extend-ignore = ["E203"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,9 +73,6 @@ disallow_untyped_defs = true
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-module = [
-    "pkg_resources",
-]
 ignore_missing_imports = true
 
 [tool.flake8]


### PR DESCRIPTION
`pkg_resources` is no longer in use, so it's not needed to override anymore.