### PR TITLE
Add finer control of <math> attributes to converter.convert

### DIFF
--- a/latex2mathml/converter.py
+++ b/latex2mathml/converter.py
@@ -2,7 +2,7 @@ import copy
 import enum
 import re
 from collections import OrderedDict
-from typing import Iterable, Iterator, Optional
+from typing import Dict, Iterable, Iterator, Optional
 from xml.etree.cElementTree import Element, SubElement, tostring
 from xml.sax.saxutils import unescape
 
@@ -64,22 +64,34 @@ class Mode(enum.Enum):
 
 def convert(
     latex: str,
-    xmlns: str = "http://www.w3.org/1998/Math/MathML",
-    display: str = "inline",
+    xmlns: Optional[str] = "http://www.w3.org/1998/Math/MathML",
+    display: Optional[str] = "inline",
+    alt_latex: bool = False,
+    alttext: Optional[str] = None,
+    attributes: Dict[str, str] = dict(),
     parent: Optional[Element] = None,
 ) -> str:
-    math = convert_to_element(latex, xmlns, display, parent)
+    math = convert_to_element(latex, xmlns, display, alt_latex, alttext, attributes, parent)
     return _convert(math)
 
 
 def convert_to_element(
     latex: str,
-    xmlns: str = "http://www.w3.org/1998/Math/MathML",
-    display: str = "inline",
+    xmlns: Optional[str] = "http://www.w3.org/1998/Math/MathML",
+    display: Optional[str] = "inline",
+    alt_latex: bool = False,
+    alttext: Optional[str] = None,
+    attributes: Dict[str, str] = dict(),
     parent: Optional[Element] = None,
 ) -> Element:
+    if alt_latex and alttext is not None:
+        raise ValueError('alttext and alt_latex should not be set simultaneously.')
+
     tag = "math"
-    attrib = {"xmlns": xmlns, "display": display}
+    alttext = latex if alt_latex else alttext
+    attrib = {"xmlns": xmlns, "display": display, "alttext": alttext}
+    attrib = {k: v for (k, v) in attrib.items() if v is not None}
+    attrib.update(attributes)
     math = Element(tag, attrib) if parent is None else SubElement(parent, tag, attrib)
     row = SubElement(math, "mrow")
     _convert_group(iter(walk(latex)), row)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -4215,6 +4215,22 @@ def test_attributes() -> None:
         convert("1", display="block")
         == '<math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mrow><mn>1</mn></mrow></math>'
     )
+    assert (
+        convert("1", xmlns=None, display=None)
+        == '<math><mrow><mn>1</mn></mrow></math>'
+    )
+    assert (
+        convert("1", xmlns=None, alttext='this is alt text')
+        == '<math display="inline" alttext="this is alt text"><mrow><mn>1</mn></mrow></math>'
+    )
+    assert (
+        convert("1", xmlns=None, alt_latex=True)
+        == '<math display="inline" alttext="1"><mrow><mn>1</mn></mrow></math>'
+    )
+    assert (
+        convert("1", attributes={"id": "eq1"})
+        == '<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline" id="eq1"><mrow><mn>1</mn></mrow></math>'
+    )
 
 
 def test_convert_to_element() -> None:


### PR DESCRIPTION
Presently, `converter.convert` has two arguments for controlling the attributes of the output `<math>` element: `xmlns` and `display`, and neither allows for these attributes to be completely absent. In this PR, I allow `None` to be passed to these arguments in order to remove these attributes, as well as adding some additional arguments:

- `alttext: Optional[str] = None`, which sets the `alttext` attribute,
- `alt_latex: bool = False`, which sets the `alttext` attribute equal to the `latex` argument, which is mutually exclusive with the previous, and
- `attributes: Dict[str, str]`, which sets arbitrary attributes.

See the test cases I added to `tests/test_converter.py` for examples of usage.