### PR TITLE
Issue 489 moverunder

### DIFF
--- a/latex2mathml/commands.py
+++ b/latex2mathml/commands.py
@@ -91,6 +91,7 @@ END = r"\end"
 LIMITS = r"\limits"
 INTEGRAL = r"\int"
 SUMMATION = r"\sum"
+PRODUCT = r"\prod"
 LIMIT = (r"\lim", r"\sup", r"\inf", r"\max", r"\min")
 
 OPERATORNAME = r"\operatorname"

--- a/latex2mathml/converter.py
+++ b/latex2mathml/converter.py
@@ -82,7 +82,7 @@ def convert_to_element(
     attrib = {"xmlns": xmlns, "display": display}
     math = Element(tag, attrib) if parent is None else SubElement(parent, tag, attrib)
     row = SubElement(math, "mrow")
-    _convert_group(iter(walk(latex)), row)
+    _convert_group(iter(walk(latex, display)), row)
     return math
 
 

--- a/latex2mathml/walker.py
+++ b/latex2mathml/walker.py
@@ -29,12 +29,13 @@ class Node(NamedTuple):
     modifier: Optional[str] = None
 
 
-def walk(data: str) -> list[Node]:
+def walk(data: str, display: str = "inline") -> list[Node]:
     tokens = tokenize(data)
-    return _walk(tokens)
+    block = True if display == "block" else False
+    return _walk(tokens, block=block)
 
 
-def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 0) -> list[Node]:
+def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 0, block: bool = False) -> list[Node]:
     group: list[Node] = []
     token: str
     has_available_tokens = False
@@ -83,6 +84,9 @@ def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 
                         raise LimitsMustFollowMathOperatorError
                 except IndexError:
                     raise LimitsMustFollowMathOperatorError
+            elif block and previous.token in (commands.SUMMATION, commands.PRODUCT):
+                # block summation and product should result in limited sub/sup
+                modifier = commands.LIMITS
 
             if token == commands.SUBSCRIPT and previous.token == commands.SUPERSCRIPT and previous.children is not None:
                 children = tuple(_walk(tokens, terminator=terminator, limit=1))


### PR DESCRIPTION
This is an attempt to resolve issue https://github.com/roniemartinez/latex2mathml/issues/489, while also improving handling for the two-line issue raised/resolved in https://github.com/roniemartinez/latex2mathml/issues/75; essentially, the `walk` function is now aware of its block/inline context, and, minimally, handles block summation, product limits above/below the sum/prod character without requiring the `\limits` marker, which conforms to the conversions expected by, say, tralics, temml, the [Overleaf documentation](https://www.overleaf.com/learn/latex/Integrals%2C_sums_and_limits#Sums_and_products), etc.
