### PR TITLE
fix: support 3+ prime marks (#462)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,3 @@
+reviews:
+  path_filters:
+    - "!tests/__snapshots__/**"

--- a/latex2mathml/commands.py
+++ b/latex2mathml/commands.py
@@ -21,7 +21,6 @@ PRIME = r"\prime"
 DPRIME = r"\dprime"
 TRPRIME = r"\trprime"
 QPRIME = r"\qprime"
-MULTIPRIMES = "multiprimes"
 PRIME_UPGRADE = {
     PRIME: DPRIME,
     DPRIME: TRPRIME,

--- a/latex2mathml/commands.py
+++ b/latex2mathml/commands.py
@@ -19,6 +19,14 @@ SUPERSCRIPT = "^"
 APOSTROPHE = "'"
 PRIME = r"\prime"
 DPRIME = r"\dprime"
+TRPRIME = r"\trprime"
+QPRIME = r"\qprime"
+MULTIPRIMES = "multiprimes"
+PRIME_UPGRADE = {
+    PRIME: DPRIME,
+    DPRIME: TRPRIME,
+    TRPRIME: QPRIME,
+}
 
 LEFT = r"\left"
 MIDDLE = r"\middle"

--- a/latex2mathml/converter.py
+++ b/latex2mathml/converter.py
@@ -8,7 +8,7 @@ from xml.sax.saxutils import unescape
 
 from latex2mathml import commands
 from latex2mathml.symbols_parser import convert_symbol
-from latex2mathml.walker import Node, walk
+from latex2mathml.walker import MULTIPRIMES, Node, walk
 
 COLUMN_ALIGNMENT_MAP = {"r": "right", "l": "left", "c": "center"}
 OPERATORS = (
@@ -472,9 +472,10 @@ def _convert_symbol(node: Node, parent: Element, font: Optional[dict[str, Option
     token = node.token
     attributes = node.attributes or {}
     symbol = convert_symbol(token)
-    if token == commands.MULTIPRIMES:
+    if token == MULTIPRIMES:
+        count = int(node.text or "0")
         element = SubElement(parent, "mi", attrib=attributes)
-        element.text = node.text or ""
+        element.text = "&#x02032;" * count
         return
     if re.match(r"\d+(.\d+)?", token):
         element = SubElement(parent, "mn", attrib=attributes)

--- a/latex2mathml/converter.py
+++ b/latex2mathml/converter.py
@@ -472,6 +472,10 @@ def _convert_symbol(node: Node, parent: Element, font: Optional[dict[str, Option
     token = node.token
     attributes = node.attributes or {}
     symbol = convert_symbol(token)
+    if token == commands.MULTIPRIMES:
+        element = SubElement(parent, "mi", attrib=attributes)
+        element.text = node.text or ""
+        return
     if re.match(r"\d+(.\d+)?", token):
         element = SubElement(parent, "mn", attrib=attributes)
         element.text = token

--- a/latex2mathml/walker.py
+++ b/latex2mathml/walker.py
@@ -18,6 +18,8 @@ from latex2mathml.exceptions import (
 from latex2mathml.symbols_parser import convert_symbol
 from latex2mathml.tokenizer import tokenize
 
+MULTIPRIMES = "multiprimes"
+
 
 class Node(NamedTuple):
     token: str
@@ -71,7 +73,7 @@ def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 
             if (token == previous.token == commands.SUPERSCRIPT) and (
                 previous.children is not None
                 and len(previous.children) >= 2
-                and previous.children[1].token not in commands.PRIME_UPGRADE
+                and previous.children[1].token != commands.PRIME
             ):
                 raise DoubleSuperscriptsError
 
@@ -130,34 +132,26 @@ def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 
             except IndexError:
                 previous = Node(token="")  # left operand can be empty if not present
 
-            previous_is_prime_super = (
-                previous.token == commands.SUPERSCRIPT
-                and previous.children is not None
-                and len(previous.children) >= 2
-                and (
-                    previous.children[1].token in commands.PRIME_UPGRADE
-                    or previous.children[1].token == commands.QPRIME
-                    or previous.children[1].token == commands.MULTIPRIMES
-                )
+            prev_is_super_with_children = (
+                previous.token == commands.SUPERSCRIPT and previous.children is not None and len(previous.children) >= 2
+            )
+            prev_prime = previous.children[1] if prev_is_super_with_children and previous.children else None
+            prev_is_prime_token = prev_prime is not None and (
+                prev_prime.token in commands.PRIME_UPGRADE
+                or prev_prime.token == commands.QPRIME
+                or prev_prime.token == MULTIPRIMES
             )
 
-            if (
-                previous.token == commands.SUPERSCRIPT
-                and previous.children is not None
-                and len(previous.children) >= 2
-                and not previous_is_prime_super
-            ):
+            if prev_is_super_with_children and not prev_is_prime_token:
                 raise DoubleSuperscriptsError
 
-            if previous_is_prime_super and previous.children is not None:
-                prev_prime = previous.children[1]
+            if prev_is_prime_token and previous.children is not None and prev_prime is not None:
                 if prev_prime.token in commands.PRIME_UPGRADE:
                     new_prime = Node(token=commands.PRIME_UPGRADE[prev_prime.token])
                 elif prev_prime.token == commands.QPRIME:
-                    new_prime = Node(token=commands.MULTIPRIMES, text="&#x02032;" * 5)
+                    new_prime = Node(token=MULTIPRIMES, text="5")
                 else:
-                    existing = prev_prime.text or ""
-                    new_prime = Node(token=commands.MULTIPRIMES, text=existing + "&#x02032;")
+                    new_prime = Node(token=MULTIPRIMES, text=str(int(prev_prime.text or "0") + 1))
                 node = Node(token=commands.SUPERSCRIPT, children=(previous.children[0], new_prime))
             elif previous.token == commands.SUBSCRIPT and previous.children is not None:
                 node = Node(

--- a/latex2mathml/walker.py
+++ b/latex2mathml/walker.py
@@ -71,7 +71,7 @@ def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 
             if (token == previous.token == commands.SUPERSCRIPT) and (
                 previous.children is not None
                 and len(previous.children) >= 2
-                and previous.children[1].token != commands.PRIME
+                and previous.children[1].token not in commands.PRIME_UPGRADE
             ):
                 raise DoubleSuperscriptsError
 
@@ -130,21 +130,35 @@ def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 
             except IndexError:
                 previous = Node(token="")  # left operand can be empty if not present
 
-            if (
+            previous_is_prime_super = (
                 previous.token == commands.SUPERSCRIPT
                 and previous.children is not None
                 and len(previous.children) >= 2
-                and previous.children[1].token != commands.PRIME
-            ):
-                raise DoubleSuperscriptsError
+                and (
+                    previous.children[1].token in commands.PRIME_UPGRADE
+                    or previous.children[1].token == commands.QPRIME
+                    or previous.children[1].token == commands.MULTIPRIMES
+                )
+            )
 
             if (
                 previous.token == commands.SUPERSCRIPT
                 and previous.children is not None
                 and len(previous.children) >= 2
-                and previous.children[1].token == commands.PRIME
+                and not previous_is_prime_super
             ):
-                node = Node(token=commands.SUPERSCRIPT, children=(previous.children[0], Node(token=commands.DPRIME)))
+                raise DoubleSuperscriptsError
+
+            if previous_is_prime_super and previous.children is not None:
+                prev_prime = previous.children[1]
+                if prev_prime.token in commands.PRIME_UPGRADE:
+                    new_prime = Node(token=commands.PRIME_UPGRADE[prev_prime.token])
+                elif prev_prime.token == commands.QPRIME:
+                    new_prime = Node(token=commands.MULTIPRIMES, text="&#x02032;" * 5)
+                else:
+                    existing = prev_prime.text or ""
+                    new_prime = Node(token=commands.MULTIPRIMES, text=existing + "&#x02032;")
+                node = Node(token=commands.SUPERSCRIPT, children=(previous.children[0], new_prime))
             elif previous.token == commands.SUBSCRIPT and previous.children is not None:
                 node = Node(
                     token=commands.SUBSUP,

--- a/tests/__snapshots__/test_converter/test_converter[issue-462-octuple-prime].html
+++ b/tests/__snapshots__/test_converter/test_converter[issue-462-octuple-prime].html
@@ -1,0 +1,1 @@
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mrow><msup><mi>f</mi><mi>&#x02032;&#x02032;&#x02032;&#x02032;&#x02032;&#x02032;&#x02032;&#x02032;</mi></msup><mo stretchy="false">&#x00028;</mo><mi>x</mi><mo stretchy="false">&#x00029;</mo></mrow></math>

--- a/tests/__snapshots__/test_converter/test_converter[issue-462-quadruple-prime].html
+++ b/tests/__snapshots__/test_converter/test_converter[issue-462-quadruple-prime].html
@@ -1,0 +1,1 @@
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mrow><msup><mi>f</mi><mi>&#x02057;</mi></msup><mo stretchy="false">&#x00028;</mo><mi>x</mi><mo stretchy="false">&#x00029;</mo></mrow></math>

--- a/tests/__snapshots__/test_converter/test_converter[issue-462-quintuple-prime].html
+++ b/tests/__snapshots__/test_converter/test_converter[issue-462-quintuple-prime].html
@@ -1,0 +1,1 @@
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mrow><msup><mi>f</mi><mi>&#x02032;&#x02032;&#x02032;&#x02032;&#x02032;</mi></msup><mo stretchy="false">&#x00028;</mo><mi>x</mi><mo stretchy="false">&#x00029;</mo></mrow></math>

--- a/tests/__snapshots__/test_converter/test_converter[issue-462-triple-prime].html
+++ b/tests/__snapshots__/test_converter/test_converter[issue-462-triple-prime].html
@@ -1,0 +1,1 @@
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mrow><msup><mi>f</mi><mi>&#x02034;</mi></msup><mo stretchy="false">&#x00028;</mo><mi>x</mi><mo stretchy="false">&#x00029;</mo></mrow></math>

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,6 +1,7 @@
 import pytest
 
 from latex2mathml.converter import convert, convert_to_element
+from latex2mathml.exceptions import DoubleSubscriptsError, DoubleSuperscriptsError
 
 
 @pytest.mark.parametrize(
@@ -386,6 +387,23 @@ def test_converter(snapshot: str, latex: str) -> None:
 )
 def test_converter_inline(snapshot: str, latex: str) -> None:
     assert convert(latex) == snapshot
+
+
+@pytest.mark.parametrize(
+    "latex",
+    [
+        "f^a^b",
+        "f''^2",
+    ],
+)
+def test_double_superscripts_raises(latex: str) -> None:
+    with pytest.raises(DoubleSuperscriptsError):
+        convert(latex)
+
+
+def test_double_subscripts_raises() -> None:
+    with pytest.raises(DoubleSubscriptsError):
+        convert("f_a_b")
 
 
 def test_convert_to_element(snapshot: str) -> None:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -117,6 +117,10 @@ from latex2mathml.converter import convert, convert_to_element
         pytest.param(r"\Bigg[\bigg[\Big[\big[[", id="big"),
         pytest.param(r"x\rm {\text{var} = 1+\{b\}}\sf \Delta", id="global-fonts"),
         pytest.param("f'(x) = 2x, f''(x) = 2", id="prime"),
+        pytest.param("f'''(x)", id="issue-462-triple-prime"),
+        pytest.param("f''''(x)", id="issue-462-quadruple-prime"),
+        pytest.param("f'''''(x)", id="issue-462-quintuple-prime"),
+        pytest.param("f''''''''(x)", id="issue-462-octuple-prime"),
         pytest.param("'x", id="prime-no-base"),
         pytest.param(
             r"""|\,|\:|\>|\;|\\|\!|\quad|\qquad|\hspace1em|\hspace{10ex}|\enspace|\hskip1em|\kern-1.5pt|\mkern10mu|


### PR DESCRIPTION
Fixes #462 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LaTeX→MathML conversion now renders higher-order prime notations (triple, quadruple, quintuple, octuple primes) correctly.

* **Bug Fixes**
  * Improved handling of nested superscripts/subscripts to correctly detect and reject invalid double superscript/subscript constructs.

* **Chores**
  * Updated review configuration to exclude test snapshot files from review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->