### PR TITLE
fix: render \href as mrow instead of mtext for proper math display

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -280,6 +280,6 @@
   "repoType": "github",
   "repoHost": "https://github.com",
   "skipCi": false,
-  "commitConvention": "none",
+  "commitConvention": "angular",
   "commitType": "docs"
 }

--- a/latex2mathml/commands.py
+++ b/latex2mathml/commands.py
@@ -660,7 +660,7 @@ CONVERSION_MAP: dict[str, tuple[str, dict]] = {
     SQRT: ("msqrt", {}),
     ROOT: ("mroot", {}),
     EMPH: ("mtext", {"mathvariant": "italic"}),
-    HREF: ("mtext", {}),
+    HREF: ("mrow", {}),
     TEXT: ("mtext", {}),
     TEXTBF: ("mtext", {"mathvariant": "bold"}),
     TEXTIT: ("mtext", {"mathvariant": "italic"}),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "latex2mathml"
-version = "3.80.0a1"
+version = "3.80.0"
 description = "Pure Python library for LaTeX to MathML conversion"
 authors = [
     { name = "Ronie Martinez", email = "ronmarti18@gmail.com" }

--- a/tests/__snapshots__/test_converter/test_converter[href].html
+++ b/tests/__snapshots__/test_converter/test_converter[href].html
@@ -1,1 +1,1 @@
-<math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mrow><mtext href="https://github.com/roniemartinez/latex2mathml"><mrow><mtext>latex2mathml</mtext></mrow></mtext></mrow></math>
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mrow><mrow href="https://github.com/roniemartinez/latex2mathml"><mrow><mtext>latex2mathml</mtext></mrow></mrow></mrow></math>

--- a/uv.lock
+++ b/uv.lock
@@ -188,7 +188,7 @@ wheels = [
 
 [[package]]
 name = "latex2mathml"
-version = "3.80.0a1"
+version = "3.80.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Fixes #495 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Releases**
  * Stable release version 3.80.0 now available

* **Improvements**
  * Enhanced MathML rendering structure for hyperlink elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->