### PR TITLE
feat: add macro support (\newcommand, \def, \DeclareMathOperator, \newenvironment)

### DIFF
--- a/latex2mathml/commands.py
+++ b/latex2mathml/commands.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from typing import Optional
 
 OPENING_BRACE = "{"
@@ -7,11 +7,7 @@ BRACES = "{}"
 
 OPENING_BRACKET = "["
 CLOSING_BRACKET = "]"
-BRACKETS = "[]"
 
-OPENING_PARENTHESIS = "("
-CLOSING_PARENTHESIS = ")"
-PARENTHESES = "()"
 
 SUBSUP = "_^"
 SUBSCRIPT = "_"
@@ -346,6 +342,7 @@ VPHANTOM = r"\vphantom"
 MATH_NON_FONT_COMMANDS = (
     MATHRING,
     MATHBIN,
+    MATHCHOICE,
     MATHCLOSE,
     MATHINNER,
     MATHOP,
@@ -510,14 +507,14 @@ COMMANDS_WITH_TWO_PARAMETERS = (
 
 BIG: dict[str, tuple[str, dict]] = {
     # command: (mathml_equivalent, attributes)
-    r"\Bigg": ("mo", OrderedDict([("minsize", "2.470em"), ("maxsize", "2.470em")])),
-    r"\bigg": ("mo", OrderedDict([("minsize", "2.047em"), ("maxsize", "2.047em")])),
-    r"\Big": ("mo", OrderedDict([("minsize", "1.623em"), ("maxsize", "1.623em")])),
-    r"\big": ("mo", OrderedDict([("minsize", "1.2em"), ("maxsize", "1.2em")])),
+    r"\Bigg": ("mo", {"minsize": "2.470em", "maxsize": "2.470em"}),
+    r"\bigg": ("mo", {"minsize": "2.047em", "maxsize": "2.047em"}),
+    r"\Big": ("mo", {"minsize": "1.623em", "maxsize": "1.623em"}),
+    r"\big": ("mo", {"minsize": "1.2em", "maxsize": "1.2em"}),
 }
 
 BIG_OPEN_CLOSE = {
-    command + postfix: (tag, OrderedDict([("stretchy", "true"), ("fence", "true"), *attrib.items()]))
+    command + postfix: (tag, {"stretchy": "true", "fence": "true", **attrib})
     for command, (tag, attrib) in BIG.items()
     for postfix in "lmr"
 }
@@ -547,7 +544,19 @@ STYLES: dict[str, tuple[str, dict]] = {
 CONVERSION_MAP: dict[str, tuple[str, dict]] = {
     # command: (mathml_equivalent, attributes)
     # tables
-    **{matrix: ("mtable", {}) for matrix in MATRICES},
+    **{
+        matrix: ("mtable", {})
+        for matrix in MATRICES
+        if matrix
+        not in (
+            DISPLAYLINES,
+            EQALIGN,
+            EQALIGNNO,
+            SMALLMATRIX,
+            SPLIT,
+            ALIGN,
+        )
+    },
     DISPLAYLINES: ("mtable", {"rowspacing": "0.5em", "columnspacing": "1em", "displaystyle": "true"}),
     EQALIGN: ("mtable", {"displaystyle": "true", "columnspacing": "0em"}),
     EQALIGNNO: ("mtable", {"displaystyle": "true", "columnspacing": "0em"}),
@@ -652,9 +661,9 @@ CONVERSION_MAP: dict[str, tuple[str, dict]] = {
     **BIG_OPEN_CLOSE,
     **MSTYLE_SIZES,
     **{limit: ("mo", {}) for limit in LIMIT},
-    LEFT: ("mo", OrderedDict([("stretchy", "true"), ("fence", "true"), ("form", "prefix")])),
-    MIDDLE: ("mo", OrderedDict([("stretchy", "true"), ("fence", "true"), ("lspace", "0.05em"), ("rspace", "0.05em")])),
-    RIGHT: ("mo", OrderedDict([("stretchy", "true"), ("fence", "true"), ("form", "postfix")])),
+    LEFT: ("mo", {"stretchy": "true", "fence": "true", "form": "prefix"}),
+    MIDDLE: ("mo", {"stretchy": "true", "fence": "true", "lspace": "0.05em", "rspace": "0.05em"}),
+    RIGHT: ("mo", {"stretchy": "true", "fence": "true", "form": "postfix"}),
     # styles
     COLOR: ("mstyle", {}),
     COLORBOX: ("mpadded", {}),

--- a/latex2mathml/commands.py
+++ b/latex2mathml/commands.py
@@ -102,9 +102,9 @@ XTWOHEADLEFTARROW = r"\xtwoheadleftarrow"
 XTWOHEADRIGHTARROW = r"\xtwoheadrightarrow"
 XHOOKLEFTARROW = r"\xhookleftarrow"
 XHOOKRIGHTARROW = r"\xhookrightarrow"
-XLEFTARROW_UPPER = r"\xLeftarrow"
-XRIGHTARROW_UPPER = r"\xRightarrow"
-XLEFTRIGHTARROW_UPPER = r"\xLeftrightarrow"
+XLEFTARROWUPPER = r"\xLeftarrow"
+XRIGHTARROWUPPER = r"\xRightarrow"
+XLEFTRIGHTARROWUPPER = r"\xLeftrightarrow"
 
 EXTENSIBLE_ARROWS: dict[str, str] = {
     XLEFTARROW: "&#x2190;",
@@ -123,9 +123,9 @@ EXTENSIBLE_ARROWS: dict[str, str] = {
     XTWOHEADRIGHTARROW: "&#x21A0;",
     XHOOKLEFTARROW: "&#x21A9;",
     XHOOKRIGHTARROW: "&#x21AA;",
-    XLEFTARROW_UPPER: "&#x21D0;",
-    XRIGHTARROW_UPPER: "&#x21D2;",
-    XLEFTRIGHTARROW_UPPER: "&#x21D4;",
+    XLEFTARROWUPPER: "&#x21D0;",
+    XRIGHTARROWUPPER: "&#x21D2;",
+    XLEFTRIGHTARROWUPPER: "&#x21D4;",
 }
 
 EMPH = r"\emph"
@@ -151,6 +151,7 @@ PRODUCT = r"\prod"
 LIMIT = (r"\lim", r"\sup", r"\inf", r"\max", r"\min")
 
 OPERATORNAME = r"\operatorname"
+OPERATORNAMESTAR = r"\operatorname*"
 OPERATORNAMEWITHLIMITS = r"\operatornamewithlimits"
 
 LBRACE = r"\{"
@@ -245,14 +246,14 @@ MATRICES = (
 )
 
 BACKSLASH = "\\"
-CARRIAGE_RETURN = r"\cr"
+CARRIAGERETURN = r"\cr"
 
 COLON = r"\:"
 COMMA = r"\,"
 DOUBLEBACKSLASH = r"\\"
 ENSPACE = r"\enspace"
 EXCLAMATION = r"\!"
-GREATER_THAN = r"\>"
+GREATERTHAN = r"\>"
 HSKIP = r"\hskip"
 HSPACE = r"\hspace"
 KERN = r"\kern"
@@ -264,7 +265,7 @@ NEGMEDSPACE = r"\negmedspace"
 NEGTHICKSPACE = r"\negthickspace"
 NOBREAKSPACE = r"\nobreakspace"
 SPACE = r"\space"
-SPACE_UPPER = r"\Space"
+SPACEUPPER = r"\Space"
 THICKSPACE = r"\thickspace"
 THINSPACE = r"\thinspace"
 QQUAD = r"\qquad"
@@ -272,9 +273,9 @@ QUAD = r"\quad"
 SEMICOLON = r"\;"
 
 BM = r"\bm"
-BLACKBOARD_BOLD = r"\Bbb"
+BLACKBOARDBOLD = r"\Bbb"
 BOLD = r"\bold"
-BOLD_SYMBOL = r"\boldsymbol"
+BOLDSYMBOL = r"\boldsymbol"
 MIT = r"\mit"
 OLDSTYLE = r"\oldstyle"
 PMB = r"\pmb"
@@ -369,7 +370,7 @@ SIDESET = r"\sideset"
 
 SKEW = r"\skew"
 TAG = r"\tag"
-TAG_STAR = r"\tag*"
+TAGSTAR = r"\tag*"
 UNICODE = r"\unicode"
 UPROOT = r"\uproot"
 VERB = r"\verb"
@@ -383,10 +384,10 @@ def font_factory(default: Optional[str], replacement: dict[str, Optional[str]]) 
 
 
 LOCAL_FONTS: dict[str, defaultdict[str, Optional[str]]] = {
-    BLACKBOARD_BOLD: font_factory("double-struck", {"fence": None}),
+    BLACKBOARDBOLD: font_factory("double-struck", {"fence": None}),
     BM: font_factory("bold-italic", {"fence": None}),
     BOLD: font_factory("bold", {"fence": None}),
-    BOLD_SYMBOL: font_factory("bold", {"mi": "bold-italic", "mtext": None}),
+    BOLDSYMBOL: font_factory("bold", {"mi": "bold-italic", "mtext": None}),
     MATHBB: font_factory("double-struck", {"fence": None}),
     MATHBF: font_factory("bold", {"fence": None}),
     MATHCAL: font_factory("script", {"fence": None}),
@@ -423,12 +424,12 @@ COMMANDS_WITH_ONE_PARAMETER = (
     ACUTE,
     BAR,
     BCANCEL,
-    BLACKBOARD_BOLD,
+    BLACKBOARDBOLD,
     BM,
     BOLD,
     BRA,
     BRAKET,
-    BOLD_SYMBOL,
+    BOLDSYMBOL,
     BOXED,
     CANCEL,
     BREVE,
@@ -610,7 +611,7 @@ CONVERSION_MAP: dict[str, tuple[str, dict]] = {
     DOUBLEBACKSLASH: ("mspace", {"linebreak": "newline"}),
     ENSPACE: ("mspace", {"width": "0.5em"}),
     EXCLAMATION: ("mspace", {"width": "negativethinmathspace"}),
-    GREATER_THAN: ("mspace", {"width": "0.222em"}),
+    GREATERTHAN: ("mspace", {"width": "0.222em"}),
     HSKIP: ("mspace", {}),
     HSPACE: ("mspace", {}),
     KERN: ("mspace", {}),
@@ -625,7 +626,7 @@ CONVERSION_MAP: dict[str, tuple[str, dict]] = {
     QQUAD: ("mspace", {"width": "2em"}),
     QUAD: ("mspace", {"width": "1em"}),
     SEMICOLON: ("mspace", {"width": "0.278em"}),
-    SPACE_UPPER: ("mspace", {"width": "0.5em"}),
+    SPACEUPPER: ("mspace", {"width": "0.5em"}),
     # overlap
     CLAP: ("mpadded", {"lspace": "-0.5width", "width": "0px"}),
     LLAP: ("mpadded", {"lspace": "-1width", "width": "0px"}),
@@ -670,7 +671,7 @@ CONVERSION_MAP: dict[str, tuple[str, dict]] = {
     TEXTSF: ("mtext", {"mathvariant": "sans-serif"}),
     TEXTTT: ("mtext", {"mathvariant": "monospace"}),
     TAG: ("mtext", {}),
-    TAG_STAR: ("mtext", {}),
+    TAGSTAR: ("mtext", {}),
     TEXTUP: ("mtext", {}),
     VERB: ("mtext", {"mathvariant": "monospace"}),
     HBOX: ("mtext", {}),

--- a/latex2mathml/commands.py
+++ b/latex2mathml/commands.py
@@ -150,6 +150,10 @@ SUMMATION = r"\sum"
 PRODUCT = r"\prod"
 LIMIT = (r"\lim", r"\sup", r"\inf", r"\max", r"\min")
 
+NEWCOMMAND = r"\newcommand"
+NEWENVIRONMENT = r"\newenvironment"
+DEF = r"\def"
+DECLAREMATHOPERATOR = r"\DeclareMathOperator"
 OPERATORNAME = r"\operatorname"
 OPERATORNAMESTAR = r"\operatorname*"
 OPERATORNAMEWITHLIMITS = r"\operatornamewithlimits"

--- a/latex2mathml/converter.py
+++ b/latex2mathml/converter.py
@@ -11,54 +11,70 @@ from latex2mathml.symbols_parser import convert_symbol
 from latex2mathml.walker import MULTIPRIMES, Node, walk
 
 COLUMN_ALIGNMENT_MAP = {"r": "right", "l": "left", "c": "center"}
-OPERATORS = (
-    "+",
-    "-",
-    "*",
-    "/",
-    "(",
-    ")",
-    "=",
-    ",",
-    "?",
-    "[",
-    "]",
-    "|",
-    r"\|",
-    "!",
-    r"\{",
-    r"\}",
-    r">",
-    r"<",
-    r".",
-    r"\ast",
-    r"\bigotimes",
-    r"\cdot",
-    r"\centerdot",
-    r"\div",
-    r"\dots",
-    r"\dotsc",
-    r"\dotso",
-    r"\gt",
-    r"\ldotp",
-    r"\lt",
-    r"\lvert",
-    r"\lVert",
-    r"\lvertneqq",
-    r"\ngeqq",
-    r"\omicron",
-    r"\rvert",
-    r"\rVert",
-    r"\S",
-    r"\smallfrown",
-    r"\smallint",
-    r"\smallsmile",
-    r"\surd",
-    r"\times",
-    r"\varsubsetneqq",
-    r"\varsupsetneqq",
+OPERATORS = frozenset(
+    (
+        "+",
+        "-",
+        "*",
+        "/",
+        "(",
+        ")",
+        "=",
+        ",",
+        "?",
+        "[",
+        "]",
+        "|",
+        r"\|",
+        "!",
+        r"\{",
+        r"\}",
+        r">",
+        r"<",
+        r".",
+        r"\ast",
+        r"\bigotimes",
+        r"\cdot",
+        r"\centerdot",
+        r"\div",
+        r"\dots",
+        r"\dotsc",
+        r"\dotso",
+        r"\gt",
+        r"\ldotp",
+        r"\lt",
+        r"\lvert",
+        r"\lVert",
+        r"\lvertneqq",
+        r"\ngeqq",
+        r"\omicron",
+        r"\rvert",
+        r"\rVert",
+        r"\S",
+        r"\smallfrown",
+        r"\smallint",
+        r"\smallsmile",
+        r"\surd",
+        r"\times",
+        r"\varsubsetneqq",
+        r"\varsupsetneqq",
+    )
 )
 MATH_MODE_PATTERN = re.compile(r"\\\$|\$|\\?[^\\$]+")
+NUMBER_PATTERN = re.compile(r"\d+(\.\d+)?")
+MOVABLE_LIMIT_TEXTS = {
+    commands.ARGMAX: "arg&#x02009;max",
+    commands.ARGMIN: "arg&#x02009;min",
+    commands.INJLIM: "inj&#x02006;lim",
+    commands.INTOP: "&#x0222B;",
+    commands.LIMINF: "lim&#x02006;inf",
+    commands.LIMSUP: "lim&#x02006;sup",
+    commands.PROJLIM: "proj&#x02006;lim",
+    commands.VARINJLIM: "inj&#x02006;lim",
+    commands.VARLIMINF: "lim&#x02006;inf",
+    commands.VARLIMSUP: "lim&#x02006;sup",
+    commands.VARPROJLIM: "proj&#x02006;lim",
+}
 
 
 class Mode(enum.Enum):
@@ -66,101 +82,461 @@ class Mode(enum.Enum):
     MATH = enum.auto()
 
 
-def convert(
-    latex: str,
-    xmlns: str = "http://www.w3.org/1998/Math/MathML",
-    display: str = "inline",
-    parent: Optional[Element] = None,
-) -> str:
-    math = convert_to_element(latex, xmlns, display, parent)
-    return _convert(math)
+class Converter:
+    def __init__(self, xmlns: str = "http://www.w3.org/1998/Math/MathML", display: str = "inline") -> None:
+        self.xmlns = xmlns
+        self.display = display
+        self.equation_counter = 0
+        self.macros: dict[str, str] = {}
 
+    def convert(self, latex: str, parent: Optional[Element] = None) -> str:
+        return self._convert(self.convert_to_element(latex, parent))
 
-def convert_to_element(
-    latex: str,
-    xmlns: str = "http://www.w3.org/1998/Math/MathML",
-    display: str = "inline",
-    parent: Optional[Element] = None,
-) -> Element:
-    tag = "math"
-    attrib = {"xmlns": xmlns, "display": display}
-    math = Element(tag, attrib) if parent is None else SubElement(parent, tag, attrib)
-    row = SubElement(math, "mrow")
-    _convert_group(iter(walk(latex, display)), row)
-    return math
+    def convert_to_element(self, latex: str, parent: Optional[Element] = None) -> Element:
+        tag = "math"
+        attrib = {"xmlns": self.xmlns, "display": self.display}
+        math = Element(tag, attrib) if parent is None else SubElement(parent, tag, attrib)
+        row = SubElement(math, "mrow")
+        self._convert_group(iter(walk(latex, self.display)), row)
+        return math
 
+    def reset(self) -> None:
+        self.equation_counter = 0
+        self.macros = {}
 
-def _convert(tree: Element) -> str:
-    return unescape(tostring(tree, encoding="unicode"))
+    @staticmethod
+    def _convert(tree: Element) -> str:
+        return unescape(tostring(tree, encoding="unicode"))
 
+    def _convert_matrix(
+        self, nodes: Iterator[Node], parent: Element, command: str, alignment: Optional[str] = None
+    ) -> None:
+        row = None
+        cell = None
 
-def _convert_matrix(nodes: Iterator[Node], parent: Element, command: str, alignment: Optional[str] = None) -> None:
-    row = None
-    cell = None
+        col_index = 0
+        col_alignment = None
 
-    col_index = 0
-    col_alignment = None
+        max_col_size = 0
 
-    max_col_size = 0
+        row_index = 0
+        row_lines: list[str] = []
 
-    row_index = 0
-    row_lines = []
+        hfil_indexes: list[bool] = []
 
-    hfil_indexes: list[bool] = []
+        for node in nodes:
+            if row is None:
+                row = SubElement(parent, "mtr")
 
-    for node in nodes:
-        if row is None:
-            row = SubElement(parent, "mtr")
+            if cell is None:
+                col_alignment, col_index = _get_column_alignment(alignment, col_alignment, col_index)
+                cell = _make_matrix_cell(row, col_alignment)
 
-        if cell is None:
-            col_alignment, col_index = _get_column_alignment(alignment, col_alignment, col_index)
-            cell = _make_matrix_cell(row, col_alignment)
+            if node.token == commands.BRACES:
+                self._convert_group(iter([node]), cell)
+            elif node.token == "&":
+                _set_cell_alignment(cell, hfil_indexes)
+                hfil_indexes = []
+                col_alignment, col_index = _get_column_alignment(alignment, col_alignment, col_index)
+                cell = _make_matrix_cell(row, col_alignment)
+                if command in (commands.SPLIT, commands.ALIGN) and col_index % 2 == 0:
+                    SubElement(cell, "mi")
+            elif node.token in (commands.DOUBLEBACKSLASH, commands.CARRIAGERETURN):
+                _set_cell_alignment(cell, hfil_indexes)
+                hfil_indexes = []
+                row_index += 1
+                if col_index > max_col_size:
+                    max_col_size = col_index
+                col_index = 0
+                col_alignment, col_index = _get_column_alignment(alignment, col_alignment, col_index)
+                row = SubElement(parent, "mtr")
+                cell = _make_matrix_cell(row, col_alignment)
+            elif node.token == commands.HLINE:
+                row_lines.append("solid")
+            elif node.token == commands.HDASHLINE:
+                row_lines.append("dashed")
+            elif node.token == commands.HFIL:
+                hfil_indexes.append(True)
+            else:
+                if row_index > len(row_lines):
+                    row_lines.append("none")
+                hfil_indexes.append(False)
+                self._convert_group(iter([node]), cell)
 
-        if node.token == commands.BRACES:
-            _convert_group(iter([node]), cell)
-        elif node.token == "&":
-            _set_cell_alignment(cell, hfil_indexes)
-            hfil_indexes = []
-            col_alignment, col_index = _get_column_alignment(alignment, col_alignment, col_index)
-            cell = _make_matrix_cell(row, col_alignment)
-            if command in (commands.SPLIT, commands.ALIGN) and col_index % 2 == 0:
-                SubElement(cell, "mi")
-        elif node.token in (commands.DOUBLEBACKSLASH, commands.CARRIAGE_RETURN):
-            _set_cell_alignment(cell, hfil_indexes)
-            hfil_indexes = []
-            row_index += 1
-            if col_index > max_col_size:
-                max_col_size = col_index
-            col_index = 0
-            col_alignment, col_index = _get_column_alignment(alignment, col_alignment, col_index)
-            row = SubElement(parent, "mtr")
-            cell = _make_matrix_cell(row, col_alignment)
-        elif node.token == commands.HLINE:
-            row_lines.append("solid")
-        elif node.token == commands.HDASHLINE:
-            row_lines.append("dashed")
-        elif node.token == commands.HFIL:
-            hfil_indexes.append(True)
+        if col_index > max_col_size:
+            max_col_size = col_index
+
+        if any(r == "solid" for r in row_lines):
+            parent.set("rowlines", " ".join(row_lines))
+
+        if row is not None and cell is not None and len(cell) == 0:
+            parent.remove(row)
+
+        if max_col_size and command == commands.ALIGN:
+            spacing = ("0em", "2em")
+            multiplier = max_col_size // len(spacing)
+            parent.set("columnspacing", " ".join(spacing * multiplier))
+
+    def _convert_group(
+        self, nodes: Iterable[Node], parent: Element, font: Optional[dict[str, Optional[str]]] = None
+    ) -> None:
+        _font = font
+        for node in nodes:
+            token = node.token
+            if token in (*commands.MSTYLE_SIZES, *commands.STYLES):
+                node = Node(token=token, children=tuple(n for n in nodes))
+                self._convert_command(node, parent, _font)
+            elif token == commands.UNICODE:
+                arg = node.children[0] if node.children else None
+                if arg and arg.children:
+                    code = "".join(c.token for c in arg.children)
+                elif arg:
+                    code = arg.token
+                else:
+                    code = ""
+                element = SubElement(parent, "mi")
+                element.text = f"&#x{code.lstrip('x')};"
+            elif token == commands.RULE:
+                attrs = node.attributes or {}
+                SubElement(parent, "mspace", mathbackground="black", width=attrs["width"], height=attrs["height"])
+            elif token in commands.CONVERSION_MAP or token in (commands.MOD, commands.PMOD, commands.POD):
+                self._convert_command(node, parent, _font)
+            elif token in commands.LOCAL_FONTS and node.children is not None:
+                self._convert_group(iter(node.children), parent, commands.LOCAL_FONTS[token])
+            elif token.startswith(commands.MATH) and node.children is not None:
+                self._convert_group(iter(node.children), parent, _font)
+            elif token in commands.GLOBAL_FONTS.keys():
+                _font = commands.GLOBAL_FONTS.get(token)
+            elif node.children is None:
+                self._convert_symbol(node, parent, _font)
+            else:
+                attributes = node.attributes or {}
+                _row = SubElement(parent, "mrow", attrib=attributes)
+                self._convert_group(iter(node.children), _row, _font)
+
+    def _convert_command(self, node: Node, parent: Element, font: Optional[dict[str, Optional[str]]] = None) -> None:
+        command = node.token
+        modifier = node.modifier
+
+        if command in (commands.SUBSTACK, commands.SMALLMATRIX):
+            parent = SubElement(parent, "mstyle", scriptlevel="1")
+        elif command == commands.CASES:
+            parent = SubElement(parent, "mrow")
+            lbrace = SubElement(
+                parent, "mo", OrderedDict([("stretchy", "true"), ("fence", "true"), ("form", "prefix")])
+            )
+            lbrace.text = "&#x{};".format(convert_symbol(commands.LBRACE))
+        elif command in (commands.DBINOM, commands.DFRAC):
+            parent = SubElement(parent, "mstyle", displaystyle="true", scriptlevel="0")
+        elif command == commands.HPHANTOM:
+            parent = SubElement(parent, "mpadded", height="0", depth="0")
+        elif command == commands.VPHANTOM:
+            parent = SubElement(parent, "mpadded", width="0")
+        elif command in (commands.TBINOM, commands.HBOX, commands.MBOX, commands.TFRAC):
+            parent = SubElement(parent, "mstyle", displaystyle="false", scriptlevel="0")
+        elif command in (commands.MOD, commands.PMOD, commands.POD):
+            SubElement(parent, "mspace", width="1em")
+
+        tag, attributes = copy.deepcopy(commands.CONVERSION_MAP[command])
+
+        if node.attributes is not None and node.token != commands.SKEW:
+            attributes.update(node.attributes)
+
+        if command == commands.LEFT:
+            parent = SubElement(parent, "mrow")
+
+        self._append_delimiter_element(node, parent, is_prefix=True)
+
+        alignment, column_lines = _get_alignment_and_column_lines(node.alignment)
+
+        if column_lines:
+            attributes["columnlines"] = column_lines
+
+        if command == commands.SUBSUP and node.children is not None and node.children[0].token == commands.GCD:
+            tag = "munderover"
+        elif command == commands.SUPERSCRIPT and modifier in (commands.LIMITS, commands.OVERBRACE):
+            tag = "mover"
+        elif command == commands.SUBSCRIPT and modifier in (commands.LIMITS, commands.UNDERBRACE):
+            tag = "munder"
+        elif command == commands.SUBSUP and modifier in (commands.LIMITS, commands.OVERBRACE, commands.UNDERBRACE):
+            tag = "munderover"
+        elif command in commands.EXTENSIBLE_ARROWS and node.children is not None and len(node.children) == 2:
+            tag = "munderover"
+
+        element = SubElement(parent, tag, attributes)
+
+        if command in commands.LIMIT:
+            element.text = command[1:]
+        elif command in (commands.MOD, commands.PMOD):
+            element.text = "mod"
+            SubElement(parent, "mspace", width="0.333em")
+        elif command == commands.POD:
+            pass
+        elif command == commands.BMOD:
+            element.text = "mod"
+        elif command in commands.EXTENSIBLE_ARROWS:
+            style = SubElement(element, "mstyle", scriptlevel="0")
+            arrow = SubElement(style, "mo")
+            arrow.text = commands.EXTENSIBLE_ARROWS[command]
+        elif command == commands.BRA:
+            SubElement(element, "mo", stretchy="false").text = "&#x27E8;"
+        elif command == commands.KET:
+            SubElement(element, "mo").text = "&#x2223;"
+        elif command == commands.BRAKET:
+            SubElement(element, "mo", stretchy="false").text = "&#x27E8;"
+        elif node.text is not None:
+            if command == commands.MIDDLE:
+                element.text = "&#x{};".format(convert_symbol(node.text))
+            elif command == commands.HBOX:
+                mtext: Optional[Element] = element
+                for text, mode in _separate_by_mode(node.text):
+                    if mode == Mode.TEXT:
+                        if mtext is None:
+                            mtext = SubElement(parent, tag, attributes)
+                        mtext.text = text.replace(" ", "&#x000A0;")
+                        self._set_font(mtext, "mtext", font)
+                        mtext = None
+                    else:
+                        _row = SubElement(parent, "mrow")
+                        self._convert_group(iter(walk(text)), _row)
+            else:
+                if command in (
+                    commands.FBOX,
+                    commands.LLAP,
+                    commands.RLAP,
+                    commands.CLAP,
+                    commands.COLORBOX,
+                    commands.FCOLORBOX,
+                ):
+                    element = SubElement(element, "mtext")
+                if command == commands.TAG:
+                    element.text = f"({node.text})"
+                elif command == commands.TAGSTAR:
+                    element.text = node.text
+                else:
+                    element.text = node.text.replace(" ", "&#x000A0;")
+                self._set_font(element, "mtext", font)
+        elif node.delimiter is not None and command not in (commands.FRAC, commands.GENFRAC):
+            if node.delimiter != ".":
+                symbol = convert_symbol(node.delimiter)
+                element.text = node.delimiter if symbol is None else "&#x{};".format(symbol)
+
+        if node.children is not None:
+            _parent = element
+            if command in (commands.LEFT, commands.MOD, commands.PMOD, commands.POD):
+                _parent = parent
+            if command in commands.MATRICES:
+                if command == commands.CASES:
+                    alignment = "l"
+                elif command in (commands.SPLIT, commands.ALIGN):
+                    alignment = "rl"
+                self._convert_matrix(iter(node.children), _parent, command, alignment=alignment)
+            elif command == commands.CFRAC:
+                for child in node.children:
+                    p = SubElement(_parent, "mstyle", displaystyle="false", scriptlevel="0")
+                    self._convert_group(iter([child]), p, font)
+            elif command == commands.SIDESET:
+                left, right = node.children
+                self._convert_group(iter([left]), _parent, font)
+                fill = SubElement(_parent, "mstyle", scriptlevel="0")
+                SubElement(fill, "mspace", width="-0.167em")
+                self._convert_group(iter([right]), _parent, font)
+            elif command == commands.SKEW:
+                child = node.children[0]
+                new_node = Node(
+                    token=child.token,
+                    children=(
+                        Node(
+                            token=commands.BRACES,
+                            children=(*child.children, Node(token=commands.MKERN, attributes=node.attributes)),
+                        ),
+                    ),
+                )
+                self._convert_group(iter([new_node]), _parent, font)
+            elif command in commands.EXTENSIBLE_ARROWS:
+                for child in node.children:
+                    padded = SubElement(
+                        _parent,
+                        "mpadded",
+                        OrderedDict(
+                            [("width", "+0.833em"), ("lspace", "0.556em"), ("voffset", "-.2em"), ("height", "-.2em")]
+                        ),
+                    )
+                    self._convert_group(iter([child]), padded, font)
+                    SubElement(padded, "mspace", depth=".25em")
+            else:
+                self._convert_group(iter(node.children), _parent, font)
+
+        _add_diacritic(command, element)
+
+        if command == commands.BRA:
+            SubElement(element, "mo").text = "&#x2223;"
+        elif command == commands.KET:
+            SubElement(element, "mo", stretchy="false").text = "&#x27E9;"
+        elif command == commands.BRAKET:
+            SubElement(element, "mo", stretchy="false").text = "&#x27E9;"
+
+        self._append_delimiter_element(node, parent, is_prefix=False)
+
+    @staticmethod
+    def _append_delimiter_element(node: Node, parent: Element, is_prefix: bool) -> None:
+        delimiter_index = 0 if is_prefix else 1
+        size = "2.047em"
+        if parent.attrib.get("displaystyle") == "false" or node.token == commands.TBINOM:
+            size = "1.2em"
+        if node.token in (r"\pmatrix", commands.PMOD, commands.POD):
+            _convert_and_append_command(r"\lparen" if is_prefix else r"\rparen", parent)
+        elif node.token in (commands.BINOM, commands.DBINOM, commands.TBINOM):
+            _convert_and_append_command(
+                r"\lparen" if is_prefix else r"\rparen", parent, {"minsize": size, "maxsize": size}
+            )
+        elif node.token == r"\bmatrix":
+            _convert_and_append_command(r"\lbrack" if is_prefix else r"\rbrack", parent)
+        elif node.token == r"\Bmatrix":
+            _convert_and_append_command(r"\lbrace" if is_prefix else r"\rbrace", parent)
+        elif node.token == r"\vmatrix":
+            _convert_and_append_command(r"\vert", parent)
+        elif node.token == r"\Vmatrix":
+            _convert_and_append_command(r"\Vert", parent)
+        elif (
+            node.token in (commands.FRAC, commands.GENFRAC)
+            and node.delimiter is not None
+            and node.delimiter[delimiter_index] != "."
+        ):
+            _convert_and_append_command(node.delimiter[delimiter_index], parent, {"minsize": size, "maxsize": size})
+        elif not is_prefix and node.token == commands.SKEW and node.attributes is not None:
+            SubElement(parent, "mspace", width="-" + node.attributes["width"])
+
+    def _convert_symbol(self, node: Node, parent: Element, font: Optional[dict[str, Optional[str]]] = None) -> None:
+        token = node.token
+        attributes = node.attributes or {}
+        symbol = convert_symbol(token)
+        if token == MULTIPRIMES:
+            count = int(node.text or "0")
+            element = SubElement(parent, "mi", attrib=attributes)
+            element.text = "&#x02032;" * count
+            return
+        if NUMBER_PATTERN.match(token):
+            element = SubElement(parent, "mn", attrib=attributes)
+            element.text = token
+            self._set_font(element, element.tag, font)
+        elif token in OPERATORS:
+            element = SubElement(parent, "mo", attrib=attributes)
+            element.text = token if symbol is None else "&#x{};".format(symbol)
+            if token == r"\|":
+                element.attrib["fence"] = "false"
+            if token == r"\smallint":
+                element.attrib["largeop"] = "false"
+            if token in ("(", ")", "[", "]", "|", r"\|", r"\{", r"\}", r"\surd"):
+                element.attrib["stretchy"] = "false"
+                self._set_font(element, "fence", font)
+            else:
+                self._set_font(element, element.tag, font)
+        elif (
+            symbol
+            and (
+                int(symbol, 16) in range(int("2200", 16), int("22FF", 16) + 1)
+                or int(symbol, 16) in range(int("2190", 16), int("21FF", 16) + 1)
+            )
+            or symbol == "."
+        ):
+            element = SubElement(parent, "mo", attrib=attributes)
+            element.text = "&#x{};".format(symbol)
+            self._set_font(element, element.tag, font)
+        elif token in (r"\ ", "~", commands.NOBREAKSPACE, commands.SPACE):
+            element = SubElement(parent, "mtext", attrib=attributes)
+            element.text = "&#x000A0;"
+            self._set_font(element, "mtext", font)
+        elif token == commands.NOT:
+            mpadded = SubElement(parent, "mpadded", width="0")
+            element = SubElement(mpadded, "mtext")
+            element.text = "&#x029F8;"
+        elif token in (
+            commands.ARGMAX,
+            commands.ARGMIN,
+            commands.DETERMINANT,
+            commands.GCD,
+            commands.INTOP,
+            commands.INJLIM,
+            commands.LIMINF,
+            commands.LIMSUP,
+            commands.PLIM,
+            commands.PR,
+            commands.PROJLIM,
+            commands.VARINJLIM,
+            commands.VARLIMINF,
+            commands.VARLIMSUP,
+            commands.VARPROJLIM,
+        ):
+            element = SubElement(parent, "mo", attrib={"movablelimits": "true", **attributes})
+            element.text = MOVABLE_LIMIT_TEXTS.get(token, token[1:])
+            self._set_font(element, element.tag, font)
+        elif token in (commands.MATHSTRUT, commands.STRUT):
+            mpadded = SubElement(parent, "mpadded", width="0px")
+            mphantom = SubElement(mpadded, "mphantom")
+            SubElement(mphantom, "mo", stretchy="false").text = "&#x00028;"
+        elif token == commands.IDOTSINT:
+            _parent = SubElement(parent, "mrow", attrib=attributes)
+            for s in ("&#x0222B;", "&#x022EF;", "&#x0222B;"):
+                element = SubElement(_parent, "mo")
+                element.text = s
+        elif token in (commands.LATEX, commands.TEX):
+            _parent = SubElement(parent, "mrow", attrib=attributes)
+            if token == commands.LATEX:
+                mi_l = SubElement(_parent, "mi")
+                mi_l.text = "L"
+                SubElement(_parent, "mspace", width="-.325em")
+                mpadded = SubElement(_parent, "mpadded", height="+.21ex", depth="-.21ex", voffset="+.21ex")
+                mstyle = SubElement(mpadded, "mstyle", displaystyle="false", scriptlevel="1")
+                mrow = SubElement(mstyle, "mrow")
+                mi_a = SubElement(mrow, "mi")
+                mi_a.text = "A"
+                SubElement(_parent, "mspace", width="-.17em")
+                self._set_font(mi_l, mi_l.tag, font)
+                self._set_font(mi_a, mi_a.tag, font)
+            mi_t = SubElement(_parent, "mi")
+            mi_t.text = "T"
+            SubElement(_parent, "mspace", width="-.14em")
+            mpadded = SubElement(_parent, "mpadded", height="-.5ex", depth="+.5ex", voffset="-.5ex")
+            mrow = SubElement(mpadded, "mrow")
+            mi_e = SubElement(mrow, "mi")
+            mi_e.text = "E"
+            SubElement(_parent, "mspace", width="-.115em")
+            mi_x = SubElement(_parent, "mi")
+            mi_x.text = "X"
+            self._set_font(mi_t, mi_t.tag, font)
+            self._set_font(mi_e, mi_e.tag, font)
+            self._set_font(mi_x, mi_x.tag, font)
+        elif token.startswith(commands.OPERATORNAMEWITHLIMITS):
+            element = SubElement(parent, "mo", attrib={"movablelimits": "true", **attributes})
+            element.text = token[len(commands.OPERATORNAMEWITHLIMITS) + 1 : -1]
+        elif token.startswith(commands.OPERATORNAMESTAR):
+            element = SubElement(parent, "mo", attrib={"movablelimits": "true", **attributes})
+            element.text = token[len(commands.OPERATORNAMESTAR) + 1 : -1]
+        elif token.startswith(commands.OPERATORNAME):
+            element = SubElement(parent, "mo", attrib=attributes)
+            element.text = token[14:-1]
+        elif token.startswith(commands.BACKSLASH):
+            element = SubElement(parent, "mi", attrib=attributes)
+            if symbol:
+                element.text = "&#x{};".format(symbol)
+            elif token in commands.FUNCTIONS:
+                element.text = token[1:]
+            else:
+                element.text = token
+            self._set_font(element, element.tag, font)
         else:
-            if row_index > len(row_lines):
-                row_lines.append("none")
-            hfil_indexes.append(False)
-            _convert_group(iter([node]), cell)
+            element = SubElement(parent, "mi", attrib=attributes)
+            element.text = token
+            self._set_font(element, element.tag, font)
 
-    if col_index > max_col_size:
-        max_col_size = col_index
-
-    if any(r == "solid" for r in row_lines):
-        parent.set("rowlines", " ".join(row_lines))
-
-    if row is not None and cell is not None and len(cell) == 0:
-        # Remove last row if it does not contain anything
-        parent.remove(row)
-
-    if max_col_size and command == commands.ALIGN:
-        spacing = ("0em", "2em")
-        multiplier = max_col_size // len(spacing)
-        parent.set("columnspacing", " ".join(spacing * multiplier))
+    @staticmethod
+    def _set_font(element: Element, key: str, font: Optional[dict[str, Optional[str]]]) -> None:
+        if font is None:
+            return
+        _font = font[key]
+        if _font is not None:
+            element.attrib["mathvariant"] = _font
 
 
 def _set_cell_alignment(cell: Element, hfil_indexes: list[bool]) -> None:
@@ -189,42 +565,6 @@ def _make_matrix_cell(row: Element, column_alignment: Optional[str]) -> Element:
     return SubElement(row, "mtd")
 
 
-def _convert_group(nodes: Iterable[Node], parent: Element, font: Optional[dict[str, Optional[str]]] = None) -> None:
-    _font = font
-    for node in nodes:
-        token = node.token
-        if token in (*commands.MSTYLE_SIZES, *commands.STYLES):
-            node = Node(token=token, children=tuple(n for n in nodes))
-            _convert_command(node, parent, _font)
-        elif token == commands.UNICODE:
-            arg = node.children[0] if node.children else None
-            if arg and arg.children:
-                code = "".join(c.token for c in arg.children)
-            elif arg:
-                code = arg.token
-            else:
-                code = ""
-            element = SubElement(parent, "mi")
-            element.text = f"&#x{code.lstrip('x')};"
-        elif token == commands.RULE:
-            attrs = node.attributes or {}
-            SubElement(parent, "mspace", mathbackground="black", width=attrs["width"], height=attrs["height"])
-        elif token in commands.CONVERSION_MAP or token in (commands.MOD, commands.PMOD, commands.POD):
-            _convert_command(node, parent, _font)
-        elif token in commands.LOCAL_FONTS and node.children is not None:
-            _convert_group(iter(node.children), parent, commands.LOCAL_FONTS[token])
-        elif token.startswith(commands.MATH) and node.children is not None:
-            _convert_group(iter(node.children), parent, _font)
-        elif token in commands.GLOBAL_FONTS.keys():
-            _font = commands.GLOBAL_FONTS.get(token)
-        elif node.children is None:
-            _convert_symbol(node, parent, _font)
-        elif node.children is not None:
-            attributes = node.attributes or {}
-            _row = SubElement(parent, "mrow", attrib=attributes)
-            _convert_group(iter(node.children), _row, _font)
-
-
 def _get_alignment_and_column_lines(alignment: Optional[str] = None) -> tuple[Optional[str], Optional[str]]:
     if alignment is None:
         return None, None
@@ -242,11 +582,11 @@ def _get_alignment_and_column_lines(alignment: Optional[str] = None) -> tuple[Op
     return _alignment, " ".join(column_lines)
 
 
-def separate_by_mode(text: str) -> Iterator[tuple[str, Mode]]:
+def _separate_by_mode(text: str) -> Iterator[tuple[str, Mode]]:
     string = ""
     is_math_mode = False
     for match in MATH_MODE_PATTERN.findall(text):
-        if match == "$":  # should match both $ and  $$
+        if match == "$":
             yield string, Mode.MATH if is_math_mode else Mode.TEXT
             string = ""
             is_math_mode = not is_math_mode
@@ -254,177 +594,6 @@ def separate_by_mode(text: str) -> Iterator[tuple[str, Mode]]:
             string += match
     if len(string):
         yield string, Mode.MATH if is_math_mode else Mode.TEXT
-    # TODO: if stays in math mode, means not terminated properly, raise error
-
-
-def _convert_command(node: Node, parent: Element, font: Optional[dict[str, Optional[str]]] = None) -> None:
-    command = node.token
-    modifier = node.modifier
-
-    if command in (commands.SUBSTACK, commands.SMALLMATRIX):
-        parent = SubElement(parent, "mstyle", scriptlevel="1")
-    elif command == commands.CASES:
-        parent = SubElement(parent, "mrow")
-        lbrace = SubElement(parent, "mo", OrderedDict([("stretchy", "true"), ("fence", "true"), ("form", "prefix")]))
-        lbrace.text = "&#x{};".format(convert_symbol(commands.LBRACE))
-    elif command in (commands.DBINOM, commands.DFRAC):
-        parent = SubElement(parent, "mstyle", displaystyle="true", scriptlevel="0")
-    elif command == commands.HPHANTOM:
-        parent = SubElement(parent, "mpadded", height="0", depth="0")
-    elif command == commands.VPHANTOM:
-        parent = SubElement(parent, "mpadded", width="0")
-    elif command in (commands.TBINOM, commands.HBOX, commands.MBOX, commands.TFRAC):
-        parent = SubElement(parent, "mstyle", displaystyle="false", scriptlevel="0")
-    elif command in (commands.MOD, commands.PMOD, commands.POD):
-        SubElement(parent, "mspace", width="1em")
-
-    tag, attributes = copy.deepcopy(commands.CONVERSION_MAP[command])
-
-    if node.attributes is not None and node.token != commands.SKEW:
-        attributes.update(node.attributes)
-
-    if command == commands.LEFT:
-        parent = SubElement(parent, "mrow")
-
-    _append_delimiter_element(node, parent, is_prefix=True)
-
-    alignment, column_lines = _get_alignment_and_column_lines(node.alignment)
-
-    if column_lines:
-        attributes["columnlines"] = column_lines
-
-    if command == commands.SUBSUP and node.children is not None and node.children[0].token == commands.GCD:
-        tag = "munderover"
-    elif command == commands.SUPERSCRIPT and modifier in (commands.LIMITS, commands.OVERBRACE):
-        tag = "mover"
-    elif command == commands.SUBSCRIPT and modifier in (commands.LIMITS, commands.UNDERBRACE):
-        tag = "munder"
-    elif command == commands.SUBSUP and modifier in (commands.LIMITS, commands.OVERBRACE, commands.UNDERBRACE):
-        tag = "munderover"
-    elif command in commands.EXTENSIBLE_ARROWS and node.children is not None and len(node.children) == 2:
-        tag = "munderover"
-
-    element = SubElement(parent, tag, attributes)
-
-    if command in commands.LIMIT:
-        element.text = command[1:]
-    elif command in (commands.MOD, commands.PMOD):
-        element.text = "mod"
-        SubElement(parent, "mspace", width="0.333em")
-    elif command == commands.POD:
-        pass
-    elif command == commands.BMOD:
-        element.text = "mod"
-    elif command in commands.EXTENSIBLE_ARROWS:
-        style = SubElement(element, "mstyle", scriptlevel="0")
-        arrow = SubElement(style, "mo")
-        arrow.text = commands.EXTENSIBLE_ARROWS[command]
-    elif command == commands.BRA:
-        SubElement(element, "mo", stretchy="false").text = "&#x27E8;"
-    elif command == commands.KET:
-        SubElement(element, "mo").text = "&#x2223;"
-    elif command == commands.BRAKET:
-        SubElement(element, "mo", stretchy="false").text = "&#x27E8;"
-    elif node.text is not None:
-        if command == commands.MIDDLE:
-            element.text = "&#x{};".format(convert_symbol(node.text))
-        elif command == commands.HBOX:
-            mtext: Optional[Element] = element
-            for text, mode in separate_by_mode(node.text):
-                if mode == Mode.TEXT:
-                    if mtext is None:
-                        mtext = SubElement(parent, tag, attributes)
-                    mtext.text = text.replace(" ", "&#x000A0;")
-                    _set_font(mtext, "mtext", font)
-                    mtext = None
-                else:
-                    _row = SubElement(parent, "mrow")
-                    _convert_group(iter(walk(text)), _row)
-        else:
-            if command in (
-                commands.FBOX,
-                commands.LLAP,
-                commands.RLAP,
-                commands.CLAP,
-                commands.COLORBOX,
-                commands.FCOLORBOX,
-            ):
-                element = SubElement(element, "mtext")
-            if command == commands.TAG:
-                element.text = f"({node.text})"
-            elif command == commands.TAG_STAR:
-                element.text = node.text
-            else:
-                element.text = node.text.replace(" ", "&#x000A0;")
-            _set_font(element, "mtext", font)
-    elif node.delimiter is not None and command not in (commands.FRAC, commands.GENFRAC):
-        if node.delimiter != ".":
-            symbol = convert_symbol(node.delimiter)
-            element.text = node.delimiter if symbol is None else "&#x{};".format(symbol)
-
-    if node.children is not None:
-        _parent = element
-        if command in (commands.LEFT, commands.MOD, commands.PMOD, commands.POD):
-            _parent = parent
-        if command in commands.MATRICES:
-            if command == commands.CASES:
-                alignment = "l"
-            elif command in (commands.SPLIT, commands.ALIGN):
-                alignment = "rl"
-            _convert_matrix(iter(node.children), _parent, command, alignment=alignment)
-        elif command == commands.CFRAC:
-            for child in node.children:
-                p = SubElement(_parent, "mstyle", displaystyle="false", scriptlevel="0")
-                _convert_group(iter([child]), p, font)
-        elif command == commands.SIDESET:
-            (
-                Node(
-                    r"\style",
-                    children=(Node(r"\mspace", attributes={"width": "-0.167em"}),),
-                    attributes={"scriptlevel": "0"},
-                ),
-            )
-            left, right = node.children
-            _convert_group(iter([left]), _parent, font)
-            fill = SubElement(_parent, "mstyle", scriptlevel="0")
-            SubElement(fill, "mspace", width="-0.167em")
-            _convert_group(iter([right]), _parent, font)
-        elif command == commands.SKEW:
-            child = node.children[0]
-            new_node = Node(
-                token=child.token,
-                children=(
-                    Node(
-                        token=commands.BRACES,
-                        children=(*child.children, Node(token=commands.MKERN, attributes=node.attributes)),
-                    ),
-                ),
-            )
-            _convert_group(iter([new_node]), _parent, font)
-        elif command in commands.EXTENSIBLE_ARROWS:
-            for child in node.children:
-                padded = SubElement(
-                    _parent,
-                    "mpadded",
-                    OrderedDict(
-                        [("width", "+0.833em"), ("lspace", "0.556em"), ("voffset", "-.2em"), ("height", "-.2em")]
-                    ),
-                )
-                _convert_group(iter([child]), padded, font)
-                SubElement(padded, "mspace", depth=".25em")
-        else:
-            _convert_group(iter(node.children), _parent, font)
-
-    _add_diacritic(command, element)
-
-    if command == commands.BRA:
-        SubElement(element, "mo").text = "&#x2223;"
-    elif command == commands.KET:
-        SubElement(element, "mo", stretchy="false").text = "&#x27E9;"
-    elif command == commands.BRAKET:
-        SubElement(element, "mo", stretchy="false").text = "&#x27E9;"
-
-    _append_delimiter_element(node, parent, is_prefix=False)
 
 
 def _add_diacritic(command: str, parent: Element) -> None:
@@ -440,177 +609,22 @@ def _convert_and_append_command(command: str, parent: Element, attributes: Optio
     mo.text = "&#x{};".format(code_point) if code_point else command
 
 
-def _append_delimiter_element(node: Node, parent: Element, is_prefix: bool) -> None:
-    delimiter_index = 0 if is_prefix else 1
-    size = "2.047em"
-    if parent.attrib.get("displaystyle") == "false" or node.token == commands.TBINOM:
-        size = "1.2em"
-    if node.token in (r"\pmatrix", commands.PMOD, commands.POD):
-        _convert_and_append_command(r"\lparen" if is_prefix else r"\rparen", parent)
-    elif node.token in (commands.BINOM, commands.DBINOM, commands.TBINOM):
-        _convert_and_append_command(r"\lparen" if is_prefix else r"\rparen", parent, {"minsize": size, "maxsize": size})
-    elif node.token == r"\bmatrix":
-        _convert_and_append_command(r"\lbrack" if is_prefix else r"\rbrack", parent)
-    elif node.token == r"\Bmatrix":
-        _convert_and_append_command(r"\lbrace" if is_prefix else r"\rbrace", parent)
-    elif node.token == r"\vmatrix":
-        _convert_and_append_command(r"\vert", parent)
-    elif node.token == r"\Vmatrix":
-        _convert_and_append_command(r"\Vert", parent)
-    elif (
-        node.token in (commands.FRAC, commands.GENFRAC)
-        and node.delimiter is not None
-        and node.delimiter[delimiter_index] != "."
-    ):
-        # TODO: use 1.2em if inline
-        _convert_and_append_command(node.delimiter[delimiter_index], parent, {"minsize": size, "maxsize": size})
-    elif not is_prefix and node.token == commands.SKEW and node.attributes is not None:
-        SubElement(parent, "mspace", width="-" + node.attributes["width"])
+def convert(
+    latex: str,
+    xmlns: str = "http://www.w3.org/1998/Math/MathML",
+    display: str = "inline",
+    parent: Optional[Element] = None,
+) -> str:
+    return Converter(xmlns=xmlns, display=display).convert(latex, parent=parent)
 
 
-def _convert_symbol(node: Node, parent: Element, font: Optional[dict[str, Optional[str]]] = None) -> None:
-    token = node.token
-    attributes = node.attributes or {}
-    symbol = convert_symbol(token)
-    if token == MULTIPRIMES:
-        count = int(node.text or "0")
-        element = SubElement(parent, "mi", attrib=attributes)
-        element.text = "&#x02032;" * count
-        return
-    if re.match(r"\d+(.\d+)?", token):
-        element = SubElement(parent, "mn", attrib=attributes)
-        element.text = token
-        _set_font(element, element.tag, font)
-    elif token in OPERATORS:
-        element = SubElement(parent, "mo", attrib=attributes)
-        element.text = token if symbol is None else "&#x{};".format(symbol)
-        if token == r"\|":
-            element.attrib["fence"] = "false"
-        if token == r"\smallint":
-            element.attrib["largeop"] = "false"
-        if token in ("(", ")", "[", "]", "|", r"\|", r"\{", r"\}", r"\surd"):
-            element.attrib["stretchy"] = "false"
-            _set_font(element, "fence", font)
-        else:
-            _set_font(element, element.tag, font)
-    elif (
-        symbol
-        and (
-            int(symbol, 16) in range(int("2200", 16), int("22FF", 16) + 1)
-            or int(symbol, 16) in range(int("2190", 16), int("21FF", 16) + 1)
-        )
-        or symbol == "."
-    ):
-        element = SubElement(parent, "mo", attrib=attributes)
-        element.text = "&#x{};".format(symbol)
-        _set_font(element, element.tag, font)
-    elif token in (r"\ ", "~", commands.NOBREAKSPACE, commands.SPACE):
-        element = SubElement(parent, "mtext", attrib=attributes)
-        element.text = "&#x000A0;"
-        _set_font(element, "mtext", font)
-    elif token == commands.NOT:
-        mpadded = SubElement(parent, "mpadded", width="0")
-        element = SubElement(mpadded, "mtext")
-        element.text = "&#x029F8;"
-    elif token in (
-        commands.ARGMAX,
-        commands.ARGMIN,
-        commands.DETERMINANT,
-        commands.GCD,
-        commands.INTOP,
-        commands.INJLIM,
-        commands.LIMINF,
-        commands.LIMSUP,
-        commands.PLIM,
-        commands.PR,
-        commands.PROJLIM,
-        commands.VARINJLIM,
-        commands.VARLIMINF,
-        commands.VARLIMSUP,
-        commands.VARPROJLIM,
-    ):
-        element = SubElement(parent, "mo", attrib={"movablelimits": "true", **attributes})
-        texts = {
-            commands.ARGMAX: "arg&#x02009;max",
-            commands.ARGMIN: "arg&#x02009;min",
-            commands.INJLIM: "inj&#x02006;lim",
-            commands.INTOP: "&#x0222B;",
-            commands.LIMINF: "lim&#x02006;inf",
-            commands.LIMSUP: "lim&#x02006;sup",
-            commands.PROJLIM: "proj&#x02006;lim",
-            commands.VARINJLIM: "inj&#x02006;lim",
-            commands.VARLIMINF: "lim&#x02006;inf",
-            commands.VARLIMSUP: "lim&#x02006;sup",
-            commands.VARPROJLIM: "proj&#x02006;lim",
-        }
-        element.text = texts.get(token, token[1:])
-        _set_font(element, element.tag, font)
-    elif token in (commands.MATHSTRUT, commands.STRUT):
-        mpadded = SubElement(parent, "mpadded", width="0px")
-        mphantom = SubElement(mpadded, "mphantom")
-        SubElement(mphantom, "mo", stretchy="false").text = "&#x00028;"
-    elif token == commands.IDOTSINT:
-        _parent = SubElement(parent, "mrow", attrib=attributes)
-        for s in ("&#x0222B;", "&#x022EF;", "&#x0222B;"):
-            element = SubElement(_parent, "mo")
-            element.text = s
-    elif token in (commands.LATEX, commands.TEX):
-        _parent = SubElement(parent, "mrow", attrib=attributes)
-        if token == commands.LATEX:
-            mi_l = SubElement(_parent, "mi")
-            mi_l.text = "L"
-            SubElement(_parent, "mspace", width="-.325em")
-            mpadded = SubElement(_parent, "mpadded", height="+.21ex", depth="-.21ex", voffset="+.21ex")
-            mstyle = SubElement(mpadded, "mstyle", displaystyle="false", scriptlevel="1")
-            mrow = SubElement(mstyle, "mrow")
-            mi_a = SubElement(mrow, "mi")
-            mi_a.text = "A"
-            SubElement(_parent, "mspace", width="-.17em")
-            _set_font(mi_l, mi_l.tag, font)
-            _set_font(mi_a, mi_a.tag, font)
-        mi_t = SubElement(_parent, "mi")
-        mi_t.text = "T"
-        SubElement(_parent, "mspace", width="-.14em")
-        mpadded = SubElement(_parent, "mpadded", height="-.5ex", depth="+.5ex", voffset="-.5ex")
-        mrow = SubElement(mpadded, "mrow")
-        mi_e = SubElement(mrow, "mi")
-        mi_e.text = "E"
-        SubElement(_parent, "mspace", width="-.115em")
-        mi_x = SubElement(_parent, "mi")
-        mi_x.text = "X"
-        _set_font(mi_t, mi_t.tag, font)
-        _set_font(mi_e, mi_e.tag, font)
-        _set_font(mi_x, mi_x.tag, font)
-    elif token.startswith(commands.OPERATORNAMEWITHLIMITS):
-        element = SubElement(parent, "mo", attrib={"movablelimits": "true", **attributes})
-        element.text = token[len(commands.OPERATORNAMEWITHLIMITS) + 1 : -1]
-    elif token.startswith(r"\operatorname*"):
-        element = SubElement(parent, "mo", attrib={"movablelimits": "true", **attributes})
-        element.text = token[15:-1]
-    elif token.startswith(commands.OPERATORNAME):
-        element = SubElement(parent, "mo", attrib=attributes)
-        element.text = token[14:-1]
-    elif token.startswith(commands.BACKSLASH):
-        element = SubElement(parent, "mi", attrib=attributes)
-        if symbol:
-            element.text = "&#x{};".format(symbol)
-        elif token in commands.FUNCTIONS:
-            element.text = token[1:]
-        else:
-            element.text = token
-        _set_font(element, element.tag, font)
-    else:
-        element = SubElement(parent, "mi", attrib=attributes)
-        element.text = token
-        _set_font(element, element.tag, font)
-
-
-def _set_font(element: Element, key: str, font: Optional[dict[str, Optional[str]]]) -> None:
-    if font is None:
-        return
-    _font = font[key]
-    if _font is not None:
-        element.attrib["mathvariant"] = _font
+def convert_to_element(
+    latex: str,
+    xmlns: str = "http://www.w3.org/1998/Math/MathML",
+    display: str = "inline",
+    parent: Optional[Element] = None,
+) -> Element:
+    return Converter(xmlns=xmlns, display=display).convert_to_element(latex, parent=parent)
 
 
 def main() -> None:  # pragma: no cover

--- a/latex2mathml/converter.py
+++ b/latex2mathml/converter.py
@@ -87,7 +87,7 @@ class Converter:
         self.xmlns = xmlns
         self.display = display
         self.equation_counter = 0
-        self.macros: dict[str, str] = {}
+        self.macros: dict[str, tuple[list[str], int]] = {}
 
     def convert(self, latex: str, parent: Optional[Element] = None) -> str:
         return self._convert(self.convert_to_element(latex, parent))
@@ -97,7 +97,7 @@ class Converter:
         attrib = {"xmlns": self.xmlns, "display": self.display}
         math = Element(tag, attrib) if parent is None else SubElement(parent, tag, attrib)
         row = SubElement(math, "mrow")
-        self._convert_group(iter(walk(latex, self.display)), row)
+        self._convert_group(iter(walk(latex, self.display, macros=self.macros)), row)
         return math
 
     def reset(self) -> None:

--- a/latex2mathml/converter.py
+++ b/latex2mathml/converter.py
@@ -1,9 +1,8 @@
 import copy
 import enum
 import re
-from collections import OrderedDict
 from typing import Iterable, Iterator, Optional
-from xml.etree.cElementTree import Element, SubElement, tostring
+from xml.etree.ElementTree import Element, SubElement, tostring
 from xml.sax.saxutils import unescape
 
 from latex2mathml import commands
@@ -86,7 +85,6 @@ class Converter:
     def __init__(self, xmlns: str = "http://www.w3.org/1998/Math/MathML", display: str = "inline") -> None:
         self.xmlns = xmlns
         self.display = display
-        self.equation_counter = 0
         self.macros: dict[str, tuple[list[str], int]] = {}
 
     def convert(self, latex: str, parent: Optional[Element] = None) -> str:
@@ -101,7 +99,6 @@ class Converter:
         return math
 
     def reset(self) -> None:
-        self.equation_counter = 0
         self.macros = {}
 
     @staticmethod
@@ -129,28 +126,28 @@ class Converter:
                 row = SubElement(parent, "mtr")
 
             if cell is None:
-                col_alignment, col_index = _get_column_alignment(alignment, col_alignment, col_index)
-                cell = _make_matrix_cell(row, col_alignment)
+                col_alignment, col_index = self._get_column_alignment(alignment, col_alignment, col_index)
+                cell = self._make_matrix_cell(row, col_alignment)
 
             if node.token == commands.BRACES:
                 self._convert_group(iter([node]), cell)
             elif node.token == "&":
-                _set_cell_alignment(cell, hfil_indexes)
+                self._set_cell_alignment(cell, hfil_indexes)
                 hfil_indexes = []
-                col_alignment, col_index = _get_column_alignment(alignment, col_alignment, col_index)
-                cell = _make_matrix_cell(row, col_alignment)
+                col_alignment, col_index = self._get_column_alignment(alignment, col_alignment, col_index)
+                cell = self._make_matrix_cell(row, col_alignment)
                 if command in (commands.SPLIT, commands.ALIGN) and col_index % 2 == 0:
                     SubElement(cell, "mi")
             elif node.token in (commands.DOUBLEBACKSLASH, commands.CARRIAGERETURN):
-                _set_cell_alignment(cell, hfil_indexes)
+                self._set_cell_alignment(cell, hfil_indexes)
                 hfil_indexes = []
                 row_index += 1
                 if col_index > max_col_size:
                     max_col_size = col_index
                 col_index = 0
-                col_alignment, col_index = _get_column_alignment(alignment, col_alignment, col_index)
+                col_alignment, col_index = self._get_column_alignment(alignment, col_alignment, col_index)
                 row = SubElement(parent, "mtr")
-                cell = _make_matrix_cell(row, col_alignment)
+                cell = self._make_matrix_cell(row, col_alignment)
             elif node.token == commands.HLINE:
                 row_lines.append("solid")
             elif node.token == commands.HDASHLINE:
@@ -166,7 +163,7 @@ class Converter:
         if col_index > max_col_size:
             max_col_size = col_index
 
-        if any(r == "solid" for r in row_lines):
+        if any(r != "none" for r in row_lines):
             parent.set("rowlines", " ".join(row_lines))
 
         if row is not None and cell is not None and len(cell) == 0:
@@ -222,9 +219,7 @@ class Converter:
             parent = SubElement(parent, "mstyle", scriptlevel="1")
         elif command == commands.CASES:
             parent = SubElement(parent, "mrow")
-            lbrace = SubElement(
-                parent, "mo", OrderedDict([("stretchy", "true"), ("fence", "true"), ("form", "prefix")])
-            )
+            lbrace = SubElement(parent, "mo", {"stretchy": "true", "fence": "true", "form": "prefix"})
             lbrace.text = "&#x{};".format(convert_symbol(commands.LBRACE))
         elif command in (commands.DBINOM, commands.DFRAC):
             parent = SubElement(parent, "mstyle", displaystyle="true", scriptlevel="0")
@@ -247,7 +242,7 @@ class Converter:
 
         self._append_delimiter_element(node, parent, is_prefix=True)
 
-        alignment, column_lines = _get_alignment_and_column_lines(node.alignment)
+        alignment, column_lines = self._get_alignment_and_column_lines(node.alignment)
 
         if column_lines:
             attributes["columnlines"] = column_lines
@@ -289,7 +284,7 @@ class Converter:
                 element.text = "&#x{};".format(convert_symbol(node.text))
             elif command == commands.HBOX:
                 mtext: Optional[Element] = element
-                for text, mode in _separate_by_mode(node.text):
+                for text, mode in self._separate_by_mode(node.text):
                     if mode == Mode.TEXT:
                         if mtext is None:
                             mtext = SubElement(parent, tag, attributes)
@@ -358,16 +353,16 @@ class Converter:
                     padded = SubElement(
                         _parent,
                         "mpadded",
-                        OrderedDict(
-                            [("width", "+0.833em"), ("lspace", "0.556em"), ("voffset", "-.2em"), ("height", "-.2em")]
-                        ),
+                        {"width": "+0.833em", "lspace": "0.556em", "voffset": "-.2em", "height": "-.2em"},
                     )
                     self._convert_group(iter([child]), padded, font)
                     SubElement(padded, "mspace", depth=".25em")
             else:
                 self._convert_group(iter(node.children), _parent, font)
 
-        _add_diacritic(command, element)
+        if command in commands.DIACRITICS:
+            text, diacritic_attrs = copy.deepcopy(commands.DIACRITICS[command])
+            SubElement(element, "mo", diacritic_attrs).text = text
 
         if command == commands.BRA:
             SubElement(element, "mo").text = "&#x2223;"
@@ -378,32 +373,33 @@ class Converter:
 
         self._append_delimiter_element(node, parent, is_prefix=False)
 
-    @staticmethod
-    def _append_delimiter_element(node: Node, parent: Element, is_prefix: bool) -> None:
+    def _append_delimiter_element(self, node: Node, parent: Element, is_prefix: bool) -> None:
         delimiter_index = 0 if is_prefix else 1
         size = "2.047em"
         if parent.attrib.get("displaystyle") == "false" or node.token == commands.TBINOM:
             size = "1.2em"
         if node.token in (r"\pmatrix", commands.PMOD, commands.POD):
-            _convert_and_append_command(r"\lparen" if is_prefix else r"\rparen", parent)
+            self._convert_and_append_command(r"\lparen" if is_prefix else r"\rparen", parent)
         elif node.token in (commands.BINOM, commands.DBINOM, commands.TBINOM):
-            _convert_and_append_command(
+            self._convert_and_append_command(
                 r"\lparen" if is_prefix else r"\rparen", parent, {"minsize": size, "maxsize": size}
             )
         elif node.token == r"\bmatrix":
-            _convert_and_append_command(r"\lbrack" if is_prefix else r"\rbrack", parent)
+            self._convert_and_append_command(r"\lbrack" if is_prefix else r"\rbrack", parent)
         elif node.token == r"\Bmatrix":
-            _convert_and_append_command(r"\lbrace" if is_prefix else r"\rbrace", parent)
+            self._convert_and_append_command(r"\lbrace" if is_prefix else r"\rbrace", parent)
         elif node.token == r"\vmatrix":
-            _convert_and_append_command(r"\vert", parent)
+            self._convert_and_append_command(r"\vert", parent)
         elif node.token == r"\Vmatrix":
-            _convert_and_append_command(r"\Vert", parent)
+            self._convert_and_append_command(r"\Vert", parent)
         elif (
             node.token in (commands.FRAC, commands.GENFRAC)
             and node.delimiter is not None
             and node.delimiter[delimiter_index] != "."
         ):
-            _convert_and_append_command(node.delimiter[delimiter_index], parent, {"minsize": size, "maxsize": size})
+            self._convert_and_append_command(
+                node.delimiter[delimiter_index], parent, {"minsize": size, "maxsize": size}
+            )
         elif not is_prefix and node.token == commands.SKEW and node.attributes is not None:
             SubElement(parent, "mspace", width="-" + node.attributes["width"])
 
@@ -515,7 +511,7 @@ class Converter:
             element.text = token[len(commands.OPERATORNAMESTAR) + 1 : -1]
         elif token.startswith(commands.OPERATORNAME):
             element = SubElement(parent, "mo", attrib=attributes)
-            element.text = token[14:-1]
+            element.text = token[len(commands.OPERATORNAME) + 1 : -1]
         elif token.startswith(commands.BACKSLASH):
             element = SubElement(parent, "mi", attrib=attributes)
             if symbol:
@@ -538,75 +534,70 @@ class Converter:
         if _font is not None:
             element.attrib["mathvariant"] = _font
 
+    @staticmethod
+    def _set_cell_alignment(cell: Element, hfil_indexes: list[bool]) -> None:
+        if cell is not None and any(hfil_indexes) and len(hfil_indexes) > 1:
+            if hfil_indexes[0] and not hfil_indexes[-1]:
+                cell.attrib["columnalign"] = "right"
+            elif not hfil_indexes[0] and hfil_indexes[-1]:
+                cell.attrib["columnalign"] = "left"
 
-def _set_cell_alignment(cell: Element, hfil_indexes: list[bool]) -> None:
-    if cell is not None and any(hfil_indexes) and len(hfil_indexes) > 1:
-        if hfil_indexes[0] and not hfil_indexes[-1]:
-            cell.attrib["columnalign"] = "right"
-        elif not hfil_indexes[0] and hfil_indexes[-1]:
-            cell.attrib["columnalign"] = "left"
+    @staticmethod
+    def _get_column_alignment(
+        alignment: Optional[str], column_alignment: Optional[str], column_index: int
+    ) -> tuple[Optional[str], int]:
+        if alignment:
+            try:
+                column_alignment = COLUMN_ALIGNMENT_MAP.get(alignment[column_index])
+            except IndexError:
+                column_alignment = COLUMN_ALIGNMENT_MAP.get(alignment[column_index % len(alignment)])
+            column_index += 1
+        return column_alignment, column_index
 
+    @staticmethod
+    def _make_matrix_cell(row: Element, column_alignment: Optional[str]) -> Element:
+        if column_alignment:
+            return SubElement(row, "mtd", columnalign=column_alignment)
+        return SubElement(row, "mtd")
 
-def _get_column_alignment(
-    alignment: Optional[str], column_alignment: Optional[str], column_index: int
-) -> tuple[Optional[str], int]:
-    if alignment:
-        try:
-            column_alignment = COLUMN_ALIGNMENT_MAP.get(alignment[column_index])
-        except IndexError:
-            column_alignment = COLUMN_ALIGNMENT_MAP.get(alignment[column_index % len(alignment)])
-        column_index += 1
-    return column_alignment, column_index
+    @staticmethod
+    def _get_alignment_and_column_lines(
+        alignment: Optional[str] = None,
+    ) -> tuple[Optional[str], Optional[str]]:
+        if alignment is None:
+            return None, None
+        if "|" not in alignment:
+            return alignment, None
+        _alignment = ""
+        column_lines: list[str] = []
+        for c in alignment:
+            if c == "|":
+                column_lines.append("solid")
+            else:
+                _alignment += c
+            if len(_alignment) - len(column_lines) == 2:
+                column_lines.append("none")
+        return _alignment, " ".join(column_lines)
 
-
-def _make_matrix_cell(row: Element, column_alignment: Optional[str]) -> Element:
-    if column_alignment:
-        return SubElement(row, "mtd", columnalign=column_alignment)
-    return SubElement(row, "mtd")
-
-
-def _get_alignment_and_column_lines(alignment: Optional[str] = None) -> tuple[Optional[str], Optional[str]]:
-    if alignment is None:
-        return None, None
-    if "|" not in alignment:
-        return alignment, None
-    _alignment = ""
-    column_lines = []
-    for c in alignment:
-        if c == "|":
-            column_lines.append("solid")
-        else:
-            _alignment += c
-        if len(_alignment) - len(column_lines) == 2:
-            column_lines.append("none")
-    return _alignment, " ".join(column_lines)
-
-
-def _separate_by_mode(text: str) -> Iterator[tuple[str, Mode]]:
-    string = ""
-    is_math_mode = False
-    for match in MATH_MODE_PATTERN.findall(text):
-        if match == "$":
+    @staticmethod
+    def _separate_by_mode(text: str) -> Iterator[tuple[str, Mode]]:
+        string = ""
+        is_math_mode = False
+        for match in MATH_MODE_PATTERN.findall(text):
+            if match == "$":
+                yield string, Mode.MATH if is_math_mode else Mode.TEXT
+                string = ""
+                is_math_mode = not is_math_mode
+            else:
+                string += match
+        if len(string):
             yield string, Mode.MATH if is_math_mode else Mode.TEXT
-            string = ""
-            is_math_mode = not is_math_mode
-        else:
-            string += match
-    if len(string):
-        yield string, Mode.MATH if is_math_mode else Mode.TEXT
 
-
-def _add_diacritic(command: str, parent: Element) -> None:
-    if command in commands.DIACRITICS:
-        text, attributes = copy.deepcopy(commands.DIACRITICS[command])
-        element = SubElement(parent, "mo", attributes)
-        element.text = text
-
-
-def _convert_and_append_command(command: str, parent: Element, attributes: Optional[dict[str, str]] = None) -> None:
-    code_point = convert_symbol(command)
-    mo = SubElement(parent, "mo", attributes if attributes is not None else {})
-    mo.text = "&#x{};".format(code_point) if code_point else command
+    @staticmethod
+    def _convert_and_append_command(command: str, parent: Element, attributes: Optional[dict[str, str]] = None) -> None:
+        code_point = convert_symbol(command)
+        mo = SubElement(parent, "mo", attributes if attributes is not None else {})
+        mo.text = "&#x{};".format(code_point) if code_point else command
 
 
 def convert(

--- a/latex2mathml/converter.py
+++ b/latex2mathml/converter.py
@@ -298,7 +298,7 @@ class Converter:
                         mtext = None
                     else:
                         _row = SubElement(parent, "mrow")
-                        self._convert_group(iter(walk(text)), _row)
+                        self._convert_group(iter(walk(text, macros=self.macros)), _row)
             else:
                 if command in (
                     commands.FBOX,

--- a/latex2mathml/converter.py
+++ b/latex2mathml/converter.py
@@ -64,10 +64,14 @@ NUMBER_PATTERN = re.compile(r"\d+(\.\d+)?")
 MOVABLE_LIMIT_TEXTS = {
     commands.ARGMAX: "arg&#x02009;max",
     commands.ARGMIN: "arg&#x02009;min",
+    commands.DETERMINANT: "det",
+    commands.GCD: "gcd",
     commands.INJLIM: "inj&#x02006;lim",
     commands.INTOP: "&#x0222B;",
     commands.LIMINF: "lim&#x02006;inf",
     commands.LIMSUP: "lim&#x02006;sup",
+    commands.PLIM: "plim",
+    commands.PR: "Pr",
     commands.PROJLIM: "proj&#x02006;lim",
     commands.VARINJLIM: "inj&#x02006;lim",
     commands.VARLIMINF: "lim&#x02006;inf",
@@ -447,25 +451,9 @@ class Converter:
             mpadded = SubElement(parent, "mpadded", width="0")
             element = SubElement(mpadded, "mtext")
             element.text = "&#x029F8;"
-        elif token in (
-            commands.ARGMAX,
-            commands.ARGMIN,
-            commands.DETERMINANT,
-            commands.GCD,
-            commands.INTOP,
-            commands.INJLIM,
-            commands.LIMINF,
-            commands.LIMSUP,
-            commands.PLIM,
-            commands.PR,
-            commands.PROJLIM,
-            commands.VARINJLIM,
-            commands.VARLIMINF,
-            commands.VARLIMSUP,
-            commands.VARPROJLIM,
-        ):
+        elif token in MOVABLE_LIMIT_TEXTS:
             element = SubElement(parent, "mo", attrib={"movablelimits": "true", **attributes})
-            element.text = MOVABLE_LIMIT_TEXTS.get(token, token[1:])
+            element.text = MOVABLE_LIMIT_TEXTS[token]
             self._set_font(element, element.tag, font)
         elif token in (commands.MATHSTRUT, commands.STRUT):
             mpadded = SubElement(parent, "mpadded", width="0px")
@@ -503,15 +491,13 @@ class Converter:
             self._set_font(mi_t, mi_t.tag, font)
             self._set_font(mi_e, mi_e.tag, font)
             self._set_font(mi_x, mi_x.tag, font)
-        elif token.startswith(commands.OPERATORNAMEWITHLIMITS):
-            element = SubElement(parent, "mo", attrib={"movablelimits": "true", **attributes})
-            element.text = token[len(commands.OPERATORNAMEWITHLIMITS) + 1 : -1]
-        elif token.startswith(commands.OPERATORNAMESTAR):
-            element = SubElement(parent, "mo", attrib={"movablelimits": "true", **attributes})
-            element.text = token[len(commands.OPERATORNAMESTAR) + 1 : -1]
         elif token.startswith(commands.OPERATORNAME):
-            element = SubElement(parent, "mo", attrib=attributes)
-            element.text = token[len(commands.OPERATORNAME) + 1 : -1]
+            for prefix in (commands.OPERATORNAMEWITHLIMITS, commands.OPERATORNAMESTAR, commands.OPERATORNAME):
+                if token.startswith(prefix):
+                    attrib = {"movablelimits": "true", **attributes} if prefix != commands.OPERATORNAME else attributes
+                    element = SubElement(parent, "mo", attrib=attrib)
+                    element.text = token[len(prefix) + 1 : -1]
+                    break
         elif token.startswith(commands.BACKSLASH):
             element = SubElement(parent, "mi", attrib=attributes)
             if symbol:
@@ -590,7 +576,7 @@ class Converter:
                 is_math_mode = not is_math_mode
             else:
                 string += match
-        if len(string):
+        if string:
             yield string, Mode.MATH if is_math_mode else Mode.TEXT
 
     @staticmethod

--- a/latex2mathml/tokenizer.py
+++ b/latex2mathml/tokenizer.py
@@ -9,7 +9,7 @@ UNITS = ("in", "mm", "cm", "pt", "em", "ex", "pc", "bp", "dd", "cc", "sp", "mu")
 PATTERN = re.compile(
     rf"""
     (?P<comment>%[^\n]+) |
-    (?P<letter>a-zA-Z) |
+    (?P<letter>[a-zA-Z]) |
     (?P<subsup_operator>[_^])(?P<subsup_digit>\d) |
     (?P<dimension>-?\d+(?:\.\d+)?\s*(?:{"|".join(UNITS)})) |
     (?P<number>\d+(?:\.\d+)?) |
@@ -52,7 +52,7 @@ def tokenize(latex_string: str, skip_comments: bool = True) -> Iterator[str]:
         for captured in tokens:
             if skip_comments and captured.startswith("%"):
                 break
-            if captured.endswith(UNITS):
+            if captured.endswith(UNITS) and captured[0:1].isdigit():
                 yield captured.replace(" ", "")
                 continue
             if captured.startswith((commands.BEGIN, commands.END, commands.OPERATORNAME)):

--- a/latex2mathml/walker.py
+++ b/latex2mathml/walker.py
@@ -296,7 +296,7 @@ def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 
             commands.MIDDLE,
             commands.RLAP,
             commands.TAG,
-            commands.TAG_STAR,
+            commands.TAGSTAR,
             commands.TEXT,
             commands.TEXTBF,
             commands.TEXTIT,

--- a/latex2mathml/walker.py
+++ b/latex2mathml/walker.py
@@ -211,14 +211,10 @@ def _walk(
             node = Node(token=token, children=children)
         elif token in (commands.HSKIP, commands.HSPACE, commands.KERN, commands.MKERN, commands.MSKIP, commands.MSPACE):
             children = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))
-            if children[0].token == commands.BRACES and children[0].children is not None:
-                children = children[0].children
-            node = Node(token=token, attributes={"width": children[0].token})
+            node = Node(token=token, attributes={"width": _unwrap_token(children[0])})
         elif token in (commands.RAISE, commands.LOWER, commands.MOVELEFT, commands.MOVERIGHT):
             dim_children = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))
-            dim = dim_children[0].token if dim_children else "0"
-            if dim_children[0].token == commands.BRACES and dim_children[0].children:
-                dim = dim_children[0].children[0].token
+            dim = _unwrap_token(dim_children[0]) if dim_children else "0"
             children = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))
             if token == commands.RAISE:
                 attributes = {"voffset": dim, "height": f"+{dim}", "depth": f"-{dim}"}
@@ -233,10 +229,7 @@ def _walk(
             dims = []
             for _ in range(2):
                 arg = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))[0]
-                if arg.token == commands.BRACES and arg.children:
-                    dims.append(arg.children[0].token)
-                else:
-                    dims.append(arg.token)
+                dims.append(_unwrap_token(arg))
             node = Node(token=token, attributes={"width": dims[0], "height": dims[1]})
         elif token == commands.SMASH:
             children = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))
@@ -288,12 +281,9 @@ def _walk(
             else:
                 group.append(choice)
             continue
-        elif token == commands.CLASS:
-            attributes = {"class": next(tokens)}
-            next_node = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))[0]
-            node = next_node._replace(attributes=attributes)
-        elif token == commands.STYLE:
-            attributes = {"style": next(tokens)}
+        elif token in (commands.CLASS, commands.STYLE):
+            attr_name = "class" if token == commands.CLASS else "style"
+            attributes = {attr_name: next(tokens)}
             next_node = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))[0]
             node = next_node._replace(attributes=attributes)
         elif token in (
@@ -352,7 +342,7 @@ def _walk(
 
             if token in (commands.ABOVE, commands.ABOVEWITHDELIMS):
                 dimension_node = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))[0]
-                dimension = _get_dimension(dimension_node)
+                dimension = _unwrap_token(dimension_node)
                 attributes = {"linethickness": dimension}
             elif token in (commands.ATOP, commands.BRACE, commands.BRACK, commands.CHOOSE):
                 attributes = {"linethickness": "0"}
@@ -421,7 +411,7 @@ def _walk(
         elif token == commands.GENFRAC:
             delimiter = next(tokens).lstrip("\\") + next(tokens).lstrip("\\")
             dimension_node, style_node = tuple(_walk(tokens, terminator=terminator, limit=2, macros=_macros))
-            dimension = _get_dimension(dimension_node)
+            dimension = _unwrap_token(dimension_node)
             style = _get_style(style_node)
             attributes = {"linethickness": dimension}
             children = tuple(_walk(tokens, terminator=terminator, limit=2, macros=_macros))
@@ -529,7 +519,7 @@ def _make_subsup(node: Node) -> tuple[str, tuple[Node, ...]]:
     return "", ()
 
 
-def _get_dimension(node: Node) -> str:
+def _unwrap_token(node: Node) -> str:
     dimension = node.token
     if node.token == commands.BRACES and node.children is not None:
         dimension = node.children[0].token
@@ -537,9 +527,7 @@ def _get_dimension(node: Node) -> str:
 
 
 def _get_style(node: Node) -> str:
-    style = node.token
-    if node.token == commands.BRACES and node.children is not None:
-        style = node.children[0].token
+    style = _unwrap_token(node)
     if style == "0":
         return commands.DISPLAYSTYLE
     if style == "1":
@@ -562,8 +550,11 @@ def _get_environment_node(
     environment = token[start_index:-1]
     env_key = f"\\begin{{{environment}}}"
     if env_key in _macros:
-        begin_body, _ = _macros[env_key]
+        begin_body, nargs = _macros[env_key]
         end_body, _ = _macros.get(f"\\end{{{environment}}}", ([], 0))
+        args: list[list[str]] = []
+        for _ in range(nargs):
+            args.append(_consume_brace_arg(tokens))
         terminator = rf"{commands.END}{{{environment}}}"
         raw_tokens: list[str] = []
         found_end = False
@@ -574,7 +565,9 @@ def _get_environment_node(
             raw_tokens.append(t)
         if not found_end:
             raise MissingEndError
-        expanded = [*begin_body, *raw_tokens, *end_body]
+        begin_expanded = _substitute_params(begin_body, args)
+        end_expanded = _substitute_params(end_body, args)
+        expanded = [*begin_expanded, *raw_tokens, *end_expanded]
         result = _walk(iter(expanded), macros=_macros, block=block)
         if len(result) == 1:
             return result[0]
@@ -615,20 +608,28 @@ def _consume_brace_arg(tokens: Iterator[str]) -> list[str]:
     return [token]
 
 
+def _parse_optional_int(tokens: Iterator[str]) -> tuple[int, str]:
+    peek = next(tokens)
+    if peek != "[":
+        return 0, peek
+    nargs_str = ""
+    for t in tokens:
+        if t == "]":
+            break
+        nargs_str += t
+    return int(nargs_str), next(tokens)
+
+
 def _parse_newcommand(tokens: Iterator[str], macros: dict[str, tuple[list[str], int]]) -> None:
     name_tokens = _consume_brace_arg(tokens)
     name = "".join(name_tokens)
-    nargs = 0
-    peek = next(tokens)
+    nargs, peek = _parse_optional_int(tokens)
     if peek == "[":
-        nargs_str = ""
         for t in tokens:
             if t == "]":
                 break
-            nargs_str += t
-        nargs = int(nargs_str)
-        body = _consume_brace_arg(tokens)
-    elif peek == "{":
+        peek = next(tokens)
+    if peek == "{":
         body = _read_until_close_brace(tokens)
     else:
         body = [peek]
@@ -655,9 +656,13 @@ def _read_until_close_brace(tokens: Iterator[str]) -> list[str]:
 def _parse_newenvironment(tokens: Iterator[str], macros: dict[str, tuple[list[str], int]]) -> None:
     name_tokens = _consume_brace_arg(tokens)
     name = "".join(name_tokens)
-    begin_body = _consume_brace_arg(tokens)
+    nargs, peek = _parse_optional_int(tokens)
+    if peek == "{":
+        begin_body = _read_until_close_brace(tokens)
+    else:
+        begin_body = [peek]
     end_body = _consume_brace_arg(tokens)
-    macros[f"\\begin{{{name}}}"] = (begin_body, 0)
+    macros[f"\\begin{{{name}}}"] = (begin_body, nargs)
     macros[f"\\end{{{name}}}"] = (end_body, 0)
 
 
@@ -683,13 +688,9 @@ def _parse_declare_math_operator(tokens: Iterator[str], macros: dict[str, tuple[
     macros[name] = ([rf"\operatorname{{{text}}}"], 0)
 
 
-def _expand_macro(token: str, tokens: Iterator[str], macros: dict[str, tuple[list[str], int]]) -> list[str]:
-    body, nargs = macros[token]
-    if nargs == 0:
+def _substitute_params(body: list[str], args: list[list[str]]) -> list[str]:
+    if not args:
         return list(body)
-    args: list[list[str]] = []
-    for _ in range(nargs):
-        args.append(_consume_brace_arg(tokens))
     expanded: list[str] = []
     body_iter = iter(body)
     for tok in body_iter:
@@ -704,3 +705,13 @@ def _expand_macro(token: str, tokens: Iterator[str], macros: dict[str, tuple[lis
         else:
             expanded.append(tok)
     return expanded
+
+
+def _expand_macro(token: str, tokens: Iterator[str], macros: dict[str, tuple[list[str], int]]) -> list[str]:
+    body, nargs = macros[token]
+    if nargs == 0:
+        return list(body)
+    args: list[list[str]] = []
+    for _ in range(nargs):
+        args.append(_consume_brace_arg(tokens))
+    return _substitute_params(body, args)

--- a/latex2mathml/walker.py
+++ b/latex2mathml/walker.py
@@ -653,8 +653,16 @@ def _parse_newenvironment(tokens: Iterator[str], macros: dict[str, tuple[list[st
 
 def _parse_def(tokens: Iterator[str], macros: dict[str, tuple[list[str], int]]) -> None:
     name = next(tokens)
-    body = _consume_brace_arg(tokens)
-    macros[name] = (body, 0)
+    nargs = 0
+    for t in tokens:
+        if t == "#":
+            param = next(tokens, "")
+            if param.isdigit():
+                nargs = max(nargs, int(param))
+        elif t == "{":
+            break
+    body = _read_until_close_brace(tokens)
+    macros[name] = (body, nargs)
 
 
 def _parse_declare_math_operator(tokens: Iterator[str], macros: dict[str, tuple[list[str], int]]) -> None:

--- a/latex2mathml/walker.py
+++ b/latex2mathml/walker.py
@@ -554,13 +554,16 @@ def _get_environment_node(
         begin_body, _ = _macros[env_key]
         end_body, _ = _macros.get(f"\\end{{{environment}}}", ([], 0))
         terminator = rf"{commands.END}{{{environment}}}"
-        content_nodes = tuple(_walk(tokens, terminator=terminator, macros=_macros))
-        if len(content_nodes) and content_nodes[-1].token == terminator:
-            content_nodes = content_nodes[:-1]
-        content_tokens: list[str] = []
-        for node in content_nodes:
-            content_tokens.append(node.token)
-        expanded = [*begin_body, *content_tokens, *end_body]
+        raw_tokens: list[str] = []
+        found_end = False
+        for t in tokens:
+            if t == terminator:
+                found_end = True
+                break
+            raw_tokens.append(t)
+        if not found_end:
+            raise MissingEndError
+        expanded = [*begin_body, *raw_tokens, *end_body]
         result = _walk(iter(expanded), macros=_macros)
         if len(result) == 1:
             return result[0]

--- a/latex2mathml/walker.py
+++ b/latex2mathml/walker.py
@@ -1,3 +1,4 @@
+from itertools import chain
 from typing import Any, Iterator, NamedTuple, Optional
 
 from latex2mathml import commands
@@ -485,8 +486,16 @@ def _walk(
             if depth >= MAX_MACRO_DEPTH:
                 raise RecursionError(f"Maximum macro expansion depth ({MAX_MACRO_DEPTH}) exceeded")
             expanded_tokens = _expand_macro(token, tokens, _macros)
-            group.extend(_walk(iter(expanded_tokens), terminator=None, block=block, macros=_macros, depth=depth + 1))
-            continue
+            if not expanded_tokens:
+                continue
+            chained = chain(iter(expanded_tokens), tokens)
+            remaining_limit = max(0, limit - len(group)) if limit else 0
+            group.extend(
+                _walk(
+                    chained, terminator=terminator, block=block, macros=_macros, depth=depth + 1, limit=remaining_limit
+                )
+            )
+            break
         else:
             node = Node(token=token)
 

--- a/latex2mathml/walker.py
+++ b/latex2mathml/walker.py
@@ -31,13 +31,20 @@ class Node(NamedTuple):
     modifier: Optional[str] = None
 
 
-def walk(data: str, display: str = "inline") -> list[Node]:
+def walk(data: str, display: str = "inline", macros: Optional[dict[str, tuple[list[str], int]]] = None) -> list[Node]:
     tokens = tokenize(data)
     block = display == "block"
-    return _walk(tokens, block=block)
+    return _walk(tokens, block=block, macros={} if macros is None else macros)
 
 
-def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 0, block: bool = False) -> list[Node]:
+def _walk(
+    tokens: Iterator[str],
+    terminator: Optional[str] = None,
+    limit: int = 0,
+    block: bool = False,
+    macros: Optional[dict[str, tuple[list[str], int]]] = None,
+) -> list[Node]:
+    _macros = {} if macros is None else macros
     group: list[Node] = []
     token: str
     has_available_tokens = False
@@ -53,12 +60,14 @@ def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 
             raise ExtraLeftOrMissingRightError
         elif token == commands.LEFT:
             delimiter = next(tokens)
-            children = tuple(_walk(tokens, terminator=commands.RIGHT))  # make \right as a child of \left
+            children = tuple(
+                _walk(tokens, terminator=commands.RIGHT, macros=_macros)
+            )  # make \right as a child of \left
             if len(children) == 0 or children[-1].token != commands.RIGHT:
                 raise ExtraLeftOrMissingRightError
             node = Node(token=token, children=children if len(children) else None, delimiter=delimiter)
         elif token == commands.OPENING_BRACE:
-            children = tuple(_walk(tokens, terminator=commands.CLOSING_BRACE))
+            children = tuple(_walk(tokens, terminator=commands.CLOSING_BRACE, macros=_macros))
             if len(children) and children[-1].token == commands.CLOSING_BRACE:
                 children = children[:-1]
             node = Node(token=commands.BRACES, children=children)
@@ -91,7 +100,7 @@ def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 
                 modifier = commands.LIMITS
 
             if token == commands.SUBSCRIPT and previous.token == commands.SUPERSCRIPT and previous.children is not None:
-                children = tuple(_walk(tokens, terminator=terminator, limit=1))
+                children = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))
                 node = Node(
                     token=commands.SUBSUP,
                     children=(previous.children[0], *children, previous.children[1]),
@@ -100,7 +109,7 @@ def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 
             elif (
                 token == commands.SUPERSCRIPT and previous.token == commands.SUBSCRIPT and previous.children is not None
             ):
-                children = tuple(_walk(tokens, terminator=terminator, limit=1))
+                children = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))
                 node = Node(token=commands.SUBSUP, children=(*previous.children, *children), modifier=previous.modifier)
             elif (
                 token == commands.SUPERSCRIPT
@@ -108,7 +117,7 @@ def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 
                 and previous.children is not None
                 and previous.children[1].token == commands.PRIME
             ):
-                children = tuple(_walk(tokens, terminator=terminator, limit=1))
+                children = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))
 
                 node = Node(
                     token=commands.SUPERSCRIPT,
@@ -120,7 +129,7 @@ def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 
                 )
             else:
                 try:
-                    children = tuple(_walk(tokens, terminator=terminator, limit=1))
+                    children = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))
                 except NoAvailableTokensError:
                     raise MissingSuperScriptOrSubscriptError
                 if previous.token in (commands.OVERBRACE, commands.UNDERBRACE):
@@ -163,18 +172,18 @@ def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 
                 node = Node(token=commands.SUPERSCRIPT, children=(previous, Node(token=commands.PRIME)))
         elif token in commands.COMMANDS_WITH_TWO_PARAMETERS:
             attributes = None
-            children = tuple(_walk(tokens, terminator=terminator, limit=2))
+            children = tuple(_walk(tokens, terminator=terminator, limit=2, macros=_macros))
             if token in (commands.OVERSET, commands.STACKREL, commands.UNDERSET):
                 children = children[::-1]
             node = Node(token=token, children=children, attributes=attributes)
         elif token in commands.COMMANDS_WITH_ONE_PARAMETER or (
             token.startswith(commands.MATH) and token not in (commands.MATHSTRUT, commands.MATHCHOICE)
         ):
-            children = tuple(_walk(tokens, terminator=terminator, limit=1))
+            children = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))
             node = Node(token=token, children=children)
         elif token == commands.NOT:
             try:
-                next_node = tuple(_walk(tokens, terminator=terminator, limit=1))[0]
+                next_node = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))[0]
                 if next_node.token.startswith("\\"):
                     negated_symbol = r"\n" + next_node.token[1:]
                     symbol = convert_symbol(negated_symbol)
@@ -188,26 +197,27 @@ def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 
             except NoAvailableTokensError:
                 node = Node(token=token)
         elif token in commands.EXTENSIBLE_ARROWS:
-            children = tuple(_walk(tokens, terminator=terminator, limit=1))
+            children = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))
             if children[0].token == commands.OPENING_BRACKET:
                 children = (
                     Node(
-                        token=commands.BRACES, children=tuple(_walk(tokens, terminator=commands.CLOSING_BRACKET))[:-1]
+                        token=commands.BRACES,
+                        children=tuple(_walk(tokens, terminator=commands.CLOSING_BRACKET, macros=_macros))[:-1],
                     ),
-                    *tuple(_walk(tokens, terminator=terminator, limit=1)),
+                    *tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros)),
                 )
             node = Node(token=token, children=children)
         elif token in (commands.HSKIP, commands.HSPACE, commands.KERN, commands.MKERN, commands.MSKIP, commands.MSPACE):
-            children = tuple(_walk(tokens, terminator=terminator, limit=1))
+            children = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))
             if children[0].token == commands.BRACES and children[0].children is not None:
                 children = children[0].children
             node = Node(token=token, attributes={"width": children[0].token})
         elif token in (commands.RAISE, commands.LOWER, commands.MOVELEFT, commands.MOVERIGHT):
-            dim_children = tuple(_walk(tokens, terminator=terminator, limit=1))
+            dim_children = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))
             dim = dim_children[0].token if dim_children else "0"
             if dim_children[0].token == commands.BRACES and dim_children[0].children:
                 dim = dim_children[0].children[0].token
-            children = tuple(_walk(tokens, terminator=terminator, limit=1))
+            children = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))
             if token == commands.RAISE:
                 attributes = {"voffset": dim, "height": f"+{dim}", "depth": f"-{dim}"}
             elif token == commands.LOWER:
@@ -220,32 +230,32 @@ def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 
         elif token == commands.RULE:
             dims = []
             for _ in range(2):
-                arg = tuple(_walk(tokens, terminator=terminator, limit=1))[0]
+                arg = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))[0]
                 if arg.token == commands.BRACES and arg.children:
                     dims.append(arg.children[0].token)
                 else:
                     dims.append(arg.token)
             node = Node(token=token, attributes={"width": dims[0], "height": dims[1]})
         elif token == commands.SMASH:
-            children = tuple(_walk(tokens, terminator=terminator, limit=1))
+            children = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))
             attributes = {"height": "0px", "depth": "0px"}
             if children[0].token == commands.OPENING_BRACKET:
-                opt = tuple(_walk(tokens, terminator=commands.CLOSING_BRACKET))[:-1]
+                opt = tuple(_walk(tokens, terminator=commands.CLOSING_BRACKET, macros=_macros))[:-1]
                 if opt and opt[0].token == "b":
                     attributes = {"depth": "0px"}
                 elif opt and opt[0].token == "t":
                     attributes = {"height": "0px"}
-                children = tuple(_walk(tokens, terminator=terminator, limit=1))
+                children = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))
             node = Node(token=token, children=children, attributes=attributes)
         elif token == commands.TEXTCOLOR:
             color = next(tokens)
-            children = tuple(_walk(tokens, terminator=terminator, limit=1))
+            children = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))
             node = Node(token=commands.COLOR, children=children, attributes={"mathcolor": color})
         elif token in (commands.COLORBOX, commands.FCOLORBOX):
             arg_count = 3 if token == commands.FCOLORBOX else 2
             args = []
             for _ in range(arg_count):
-                arg_node = tuple(_walk(tokens, terminator=terminator, limit=1))[0]
+                arg_node = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))[0]
                 args.append("".join(c.token for c in arg_node.children) if arg_node.children else "")
             if token == commands.FCOLORBOX:
                 attributes = {"mathbackground": args[1], "border-color": args[0]}
@@ -254,7 +264,7 @@ def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 
             node = Node(token=token, text=args[-1], attributes=attributes)
         elif token == commands.COLOR:
             attributes = {"mathcolor": next(tokens)}
-            children = tuple(_walk(tokens, terminator=terminator))
+            children = tuple(_walk(tokens, terminator=terminator, macros=_macros))
             sibling = None
             if len(children) and children[-1].token == terminator:
                 children, sibling = children[:-1], children[-1]
@@ -264,10 +274,10 @@ def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 
             break
         elif token in (commands.LEFTROOT, commands.UPROOT):
             # Consume the numeric argument but discard — MathML has no root index positioning
-            tuple(_walk(tokens, terminator=terminator, limit=1))
+            tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))
             continue
         elif token == commands.MATHCHOICE:
-            choices = tuple(_walk(tokens, terminator=terminator, limit=4))
+            choices = tuple(_walk(tokens, terminator=terminator, limit=4, macros=_macros))
             # In block (display) mode use arg 0, in inline (text) mode use arg 1
             choice = choices[0] if block else choices[1]
             if choice.children:
@@ -278,11 +288,11 @@ def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 
             continue
         elif token == commands.CLASS:
             attributes = {"class": next(tokens)}
-            next_node = tuple(_walk(tokens, terminator=terminator, limit=1))[0]
+            next_node = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))[0]
             node = next_node._replace(attributes=attributes)
         elif token == commands.STYLE:
             attributes = {"style": next(tokens)}
-            next_node = tuple(_walk(tokens, terminator=terminator, limit=1))[0]
+            next_node = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))[0]
             node = next_node._replace(attributes=attributes)
         elif token in (
             *commands.BIG.keys(),
@@ -311,7 +321,7 @@ def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 
             node = Node(token=token, text=next(tokens))
         elif token == commands.HREF:
             attributes = {"href": next(tokens)}
-            children = tuple(_walk(tokens, terminator=terminator, limit=1))
+            children = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))
             node = Node(token=token, children=children, attributes=attributes)
         elif token in (
             commands.ABOVE,
@@ -339,13 +349,13 @@ def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 
                 delimiter = "()"
 
             if token in (commands.ABOVE, commands.ABOVEWITHDELIMS):
-                dimension_node = tuple(_walk(tokens, terminator=terminator, limit=1))[0]
+                dimension_node = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))[0]
                 dimension = _get_dimension(dimension_node)
                 attributes = {"linethickness": dimension}
             elif token in (commands.ATOP, commands.BRACE, commands.BRACK, commands.CHOOSE):
                 attributes = {"linethickness": "0"}
 
-            denominator = tuple(_walk(tokens, terminator=terminator))
+            denominator = tuple(_walk(tokens, terminator=terminator, macros=_macros))
 
             sibling = None
             if len(denominator) and denominator[-1].token == terminator:
@@ -374,10 +384,10 @@ def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 
             break
         elif token == commands.SQRT:
             root_nodes = None
-            next_node = tuple(_walk(tokens, limit=1))[0]
+            next_node = tuple(_walk(tokens, limit=1, macros=_macros))[0]
             if next_node.token == commands.OPENING_BRACKET:
-                root_nodes = tuple(_walk(tokens, terminator=commands.CLOSING_BRACKET))[:-1]
-                next_node = tuple(_walk(tokens, limit=1))[0]
+                root_nodes = tuple(_walk(tokens, terminator=commands.CLOSING_BRACKET, macros=_macros))[:-1]
+                next_node = tuple(_walk(tokens, limit=1, macros=_macros))[0]
                 if len(root_nodes) > 1:
                     root_nodes = (Node(token=commands.BRACES, children=root_nodes),)
 
@@ -386,8 +396,8 @@ def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 
             else:
                 node = Node(token=token, children=(next_node,))
         elif token == commands.ROOT:
-            root_nodes = tuple(_walk(tokens, terminator=r"\of"))[:-1]
-            next_node = tuple(_walk(tokens, limit=1))[0]
+            root_nodes = tuple(_walk(tokens, terminator=r"\of", macros=_macros))[:-1]
+            next_node = tuple(_walk(tokens, limit=1, macros=_macros))[0]
             if len(root_nodes) > 1:
                 root_nodes = (Node(token=commands.BRACES, children=root_nodes),)
             if root_nodes:
@@ -395,7 +405,7 @@ def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 
             else:
                 node = Node(token=token, children=(next_node, Node(token=commands.BRACES, children=())))
         elif token in commands.MATRICES:
-            children = tuple(_walk(tokens, terminator=terminator))
+            children = tuple(_walk(tokens, terminator=terminator, macros=_macros))
             sibling = None
             if len(children) and children[-1].token == terminator:
                 children, sibling = children[:-1], children[-1]
@@ -408,17 +418,17 @@ def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 
                 node = Node(token=token, children=children, alignment="")
         elif token == commands.GENFRAC:
             delimiter = next(tokens).lstrip("\\") + next(tokens).lstrip("\\")
-            dimension_node, style_node = tuple(_walk(tokens, terminator=terminator, limit=2))
+            dimension_node, style_node = tuple(_walk(tokens, terminator=terminator, limit=2, macros=_macros))
             dimension = _get_dimension(dimension_node)
             style = _get_style(style_node)
             attributes = {"linethickness": dimension}
-            children = tuple(_walk(tokens, terminator=terminator, limit=2))
+            children = tuple(_walk(tokens, terminator=terminator, limit=2, macros=_macros))
             group.extend(
                 [Node(token=style), Node(token=token, children=children, delimiter=delimiter, attributes=attributes)]
             )
             break
         elif token == commands.SIDESET:
-            left, right, operator = tuple(_walk(tokens, terminator=terminator, limit=3))
+            left, right, operator = tuple(_walk(tokens, terminator=terminator, limit=3, macros=_macros))
             left_token, left_children = _make_subsup(left)
             right_token, right_children = _make_subsup(right)
             attributes = {"movablelimits": "false"}
@@ -447,7 +457,7 @@ def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 
                 ),
             )
         elif token == commands.SKEW:
-            width_node, child = tuple(_walk(tokens, terminator=terminator, limit=2))
+            width_node, child = tuple(_walk(tokens, terminator=terminator, limit=2, macros=_macros))
             width = width_node.token
             if width == commands.BRACES:
                 if width_node.children is None or len(width_node.children) == 0:
@@ -457,7 +467,23 @@ def _walk(tokens: Iterator[str], terminator: Optional[str] = None, limit: int = 
                 raise InvalidWidthError
             node = Node(token=token, children=(child,), attributes={"width": f"{0.0555 * int(width):.3f}em"})
         elif token.startswith(commands.BEGIN):
-            node = _get_environment_node(token, tokens)
+            node = _get_environment_node(token, tokens, macros=_macros)
+        elif token == commands.NEWCOMMAND:
+            _parse_newcommand(tokens, _macros)
+            continue
+        elif token == commands.DEF:
+            _parse_def(tokens, _macros)
+            continue
+        elif token == commands.DECLAREMATHOPERATOR:
+            _parse_declare_math_operator(tokens, _macros)
+            continue
+        elif token == commands.NEWENVIRONMENT:
+            _parse_newenvironment(tokens, _macros)
+            continue
+        elif token in _macros:
+            expanded_tokens = _expand_macro(token, tokens, _macros)
+            group.extend(_walk(iter(expanded_tokens), terminator=None, block=block, macros=_macros))
+            continue
         else:
             node = Node(token=token)
 
@@ -513,12 +539,30 @@ def _get_style(node: Node) -> str:
     raise InvalidStyleForGenfracError
 
 
-def _get_environment_node(token: str, tokens: Iterator[str]) -> Node:
-    # TODO: support non-matrix environments
+def _get_environment_node(
+    token: str, tokens: Iterator[str], macros: Optional[dict[str, tuple[list[str], int]]] = None
+) -> Node:
+    _macros = {} if macros is None else macros
     start_index = token.index("{") + 1
     environment = token[start_index:-1]
+    env_key = f"\\begin{{{environment}}}"
+    if env_key in _macros:
+        begin_body, _ = _macros[env_key]
+        end_body, _ = _macros.get(f"\\end{{{environment}}}", ([], 0))
+        terminator = rf"{commands.END}{{{environment}}}"
+        content_nodes = tuple(_walk(tokens, terminator=terminator, macros=_macros))
+        if len(content_nodes) and content_nodes[-1].token == terminator:
+            content_nodes = content_nodes[:-1]
+        content_tokens: list[str] = []
+        for node in content_nodes:
+            content_tokens.append(node.token)
+        expanded = [*begin_body, *content_tokens, *end_body]
+        result = _walk(iter(expanded), macros=_macros)
+        if len(result) == 1:
+            return result[0]
+        return Node(token=commands.BRACES, children=tuple(result))
     terminator = rf"{commands.END}{{{environment}}}"
-    children = tuple(_walk(tokens, terminator=terminator))
+    children = tuple(_walk(tokens, terminator=terminator, macros=macros))
     if len(children) and children[-1].token != terminator:
         raise MissingEndError
     children = children[:-1]
@@ -547,3 +591,91 @@ def _get_environment_node(token: str, tokens: Iterator[str]) -> Node:
         children = children[1:]
 
     return Node(token=rf"\{environment}", children=children, alignment=alignment)
+
+
+def _consume_brace_arg(tokens: Iterator[str]) -> list[str]:
+    token = next(tokens)
+    if token == "{":
+        return _read_until_close_brace(tokens)
+    return [token]
+
+
+def _parse_newcommand(tokens: Iterator[str], macros: dict[str, tuple[list[str], int]]) -> None:
+    name_tokens = _consume_brace_arg(tokens)
+    name = name_tokens[0] if name_tokens else ""
+    nargs = 0
+    peek = next(tokens)
+    if peek == "[":
+        nargs_str = ""
+        for t in tokens:
+            if t == "]":
+                break
+            nargs_str += t
+        nargs = int(nargs_str)
+        body = _consume_brace_arg(tokens)
+    else:
+        body = _read_until_close_brace(tokens)
+    macros[name] = (body, nargs)
+
+
+def _read_until_close_brace(tokens: Iterator[str]) -> list[str]:
+    depth = 1
+    content: list[str] = []
+    for t in tokens:
+        if t == "{":
+            depth += 1
+            content.append(t)
+        elif t == "}":
+            depth -= 1
+            if depth == 0:
+                return content
+            content.append(t)
+        else:
+            content.append(t)
+    return content
+
+
+def _parse_newenvironment(tokens: Iterator[str], macros: dict[str, tuple[list[str], int]]) -> None:
+    name_tokens = _consume_brace_arg(tokens)
+    name = "".join(name_tokens)
+    begin_body = _consume_brace_arg(tokens)
+    end_body = _consume_brace_arg(tokens)
+    macros[f"\\begin{{{name}}}"] = (begin_body, 0)
+    macros[f"\\end{{{name}}}"] = (end_body, 0)
+
+
+def _parse_def(tokens: Iterator[str], macros: dict[str, tuple[list[str], int]]) -> None:
+    name = next(tokens)
+    body = _consume_brace_arg(tokens)
+    macros[name] = (body, 0)
+
+
+def _parse_declare_math_operator(tokens: Iterator[str], macros: dict[str, tuple[list[str], int]]) -> None:
+    name_tokens = _consume_brace_arg(tokens)
+    name = name_tokens[0] if name_tokens else ""
+    text_tokens = _consume_brace_arg(tokens)
+    text = "".join(text_tokens)
+    macros[name] = ([rf"\operatorname{{{text}}}"], 0)
+
+
+def _expand_macro(token: str, tokens: Iterator[str], macros: dict[str, tuple[list[str], int]]) -> list[str]:
+    body, nargs = macros[token]
+    if nargs == 0:
+        return list(body)
+    args: list[list[str]] = []
+    for _ in range(nargs):
+        args.append(_consume_brace_arg(tokens))
+    expanded: list[str] = []
+    body_iter = iter(body)
+    for tok in body_iter:
+        if tok == "#":
+            param_num = next(body_iter, "")
+            if param_num.isdigit() and 1 <= int(param_num) <= len(args):
+                expanded.extend(args[int(param_num) - 1])
+            else:
+                expanded.append(tok)
+                if param_num:
+                    expanded.append(param_num)
+        else:
+            expanded.append(tok)
+    return expanded

--- a/latex2mathml/walker.py
+++ b/latex2mathml/walker.py
@@ -19,6 +19,7 @@ from latex2mathml.symbols_parser import convert_symbol
 from latex2mathml.tokenizer import tokenize
 
 MULTIPRIMES = "multiprimes"
+MAX_MACRO_DEPTH = 100
 
 
 class Node(NamedTuple):
@@ -43,6 +44,7 @@ def _walk(
     limit: int = 0,
     block: bool = False,
     macros: Optional[dict[str, tuple[list[str], int]]] = None,
+    depth: int = 0,
 ) -> list[Node]:
     _macros = {} if macros is None else macros
     group: list[Node] = []
@@ -481,8 +483,10 @@ def _walk(
             _parse_newenvironment(tokens, _macros)
             continue
         elif token in _macros:
+            if depth >= MAX_MACRO_DEPTH:
+                raise RecursionError(f"Maximum macro expansion depth ({MAX_MACRO_DEPTH}) exceeded")
             expanded_tokens = _expand_macro(token, tokens, _macros)
-            group.extend(_walk(iter(expanded_tokens), terminator=None, block=block, macros=_macros))
+            group.extend(_walk(iter(expanded_tokens), terminator=None, block=block, macros=_macros, depth=depth + 1))
             continue
         else:
             node = Node(token=token)

--- a/latex2mathml/walker.py
+++ b/latex2mathml/walker.py
@@ -67,7 +67,7 @@ def _walk(
             )  # make \right as a child of \left
             if len(children) == 0 or children[-1].token != commands.RIGHT:
                 raise ExtraLeftOrMissingRightError
-            node = Node(token=token, children=children if len(children) else None, delimiter=delimiter)
+            node = Node(token=token, children=children, delimiter=delimiter)
         elif token == commands.OPENING_BRACE:
             children = tuple(_walk(tokens, terminator=commands.CLOSING_BRACE, macros=_macros))
             if len(children) and children[-1].token == commands.CLOSING_BRACE:
@@ -173,13 +173,12 @@ def _walk(
             else:
                 node = Node(token=commands.SUPERSCRIPT, children=(previous, Node(token=commands.PRIME)))
         elif token in commands.COMMANDS_WITH_TWO_PARAMETERS:
-            attributes = None
             children = tuple(_walk(tokens, terminator=terminator, limit=2, macros=_macros))
             if token in (commands.OVERSET, commands.STACKREL, commands.UNDERSET):
                 children = children[::-1]
-            node = Node(token=token, children=children, attributes=attributes)
+            node = Node(token=token, children=children)
         elif token in commands.COMMANDS_WITH_ONE_PARAMETER or (
-            token.startswith(commands.MATH) and token not in (commands.MATHSTRUT, commands.MATHCHOICE)
+            token.startswith(commands.MATH) and token not in commands.MATH_NON_FONT_COMMANDS
         ):
             children = tuple(_walk(tokens, terminator=terminator, limit=1, macros=_macros))
             node = Node(token=token, children=children)
@@ -469,7 +468,7 @@ def _walk(
                 raise InvalidWidthError
             node = Node(token=token, children=(child,), attributes={"width": f"{0.0555 * int(width):.3f}em"})
         elif token.startswith(commands.BEGIN):
-            node = _get_environment_node(token, tokens, macros=_macros)
+            node = _get_environment_node(token, tokens, macros=_macros, block=block)
         elif token == commands.NEWCOMMAND:
             _parse_newcommand(tokens, _macros)
             continue
@@ -544,7 +543,10 @@ def _get_style(node: Node) -> str:
 
 
 def _get_environment_node(
-    token: str, tokens: Iterator[str], macros: Optional[dict[str, tuple[list[str], int]]] = None
+    token: str,
+    tokens: Iterator[str],
+    macros: Optional[dict[str, tuple[list[str], int]]] = None,
+    block: bool = False,
 ) -> Node:
     _macros = {} if macros is None else macros
     start_index = token.index("{") + 1
@@ -564,12 +566,12 @@ def _get_environment_node(
         if not found_end:
             raise MissingEndError
         expanded = [*begin_body, *raw_tokens, *end_body]
-        result = _walk(iter(expanded), macros=_macros)
+        result = _walk(iter(expanded), macros=_macros, block=block)
         if len(result) == 1:
             return result[0]
         return Node(token=commands.BRACES, children=tuple(result))
     terminator = rf"{commands.END}{{{environment}}}"
-    children = tuple(_walk(tokens, terminator=terminator, macros=macros))
+    children = tuple(_walk(tokens, terminator=terminator, macros=macros, block=block))
     if len(children) and children[-1].token != terminator:
         raise MissingEndError
     children = children[:-1]
@@ -588,10 +590,7 @@ def _get_environment_node(
     elif (
         len(children)
         and children[0].children is not None
-        and (
-            children[0].token == commands.BRACES
-            or (environment.endswith("*") and children[0].token == commands.BRACKETS)
-        )
+        and children[0].token == commands.BRACES
         and all(c.token in "lcr|" for c in children[0].children)
     ):
         alignment = "".join(c.token for c in children[0].children)
@@ -609,7 +608,7 @@ def _consume_brace_arg(tokens: Iterator[str]) -> list[str]:
 
 def _parse_newcommand(tokens: Iterator[str], macros: dict[str, tuple[list[str], int]]) -> None:
     name_tokens = _consume_brace_arg(tokens)
-    name = name_tokens[0] if name_tokens else ""
+    name = "".join(name_tokens)
     nargs = 0
     peek = next(tokens)
     if peek == "[":
@@ -620,8 +619,10 @@ def _parse_newcommand(tokens: Iterator[str], macros: dict[str, tuple[list[str], 
             nargs_str += t
         nargs = int(nargs_str)
         body = _consume_brace_arg(tokens)
-    else:
+    elif peek == "{":
         body = _read_until_close_brace(tokens)
+    else:
+        body = [peek]
     macros[name] = (body, nargs)
 
 
@@ -667,7 +668,7 @@ def _parse_def(tokens: Iterator[str], macros: dict[str, tuple[list[str], int]]) 
 
 def _parse_declare_math_operator(tokens: Iterator[str], macros: dict[str, tuple[list[str], int]]) -> None:
     name_tokens = _consume_brace_arg(tokens)
-    name = name_tokens[0] if name_tokens else ""
+    name = "".join(name_tokens)
     text_tokens = _consume_brace_arg(tokens)
     text = "".join(text_tokens)
     macros[name] = ([rf"\operatorname{{{text}}}"], 0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "latex2mathml"
-version = "3.80.0"
+version = "3.81.0a1"
 description = "Pure Python library for LaTeX to MathML conversion"
 authors = [
     { name = "Ronie Martinez", email = "ronmarti18@gmail.com" }

--- a/tests/__snapshots__/test_converter/test_converter[moveleft].html
+++ b/tests/__snapshots__/test_converter/test_converter[moveleft].html
@@ -1,0 +1,1 @@
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mrow><mpadded lspace="-5pt"><mrow><mi>x</mi></mrow></mpadded></mrow></math>

--- a/tests/__snapshots__/test_converter/test_converter[moveright].html
+++ b/tests/__snapshots__/test_converter/test_converter[moveright].html
@@ -1,0 +1,1 @@
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mrow><mpadded lspace="5pt"><mrow><mi>x</mi></mrow></mpadded></mrow></math>

--- a/tests/__snapshots__/test_converter/test_converter[newenvironment-multi-node].html
+++ b/tests/__snapshots__/test_converter/test_converter[newenvironment-multi-node].html
@@ -1,0 +1,1 @@
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mrow><mrow><mi>a</mi><mo>&#x0002B;</mo><mi>b</mi><mo>&#x0002B;</mo><mi>c</mi></mrow></mrow></math>

--- a/tests/__snapshots__/test_converter/test_converter[smash-top].html
+++ b/tests/__snapshots__/test_converter/test_converter[smash-top].html
@@ -1,0 +1,1 @@
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mrow><mpadded height="0px"><mrow><mi>x</mi></mrow></mpadded></mrow></math>

--- a/tests/__snapshots__/test_converter/test_converter_inline[def-with-args].html
+++ b/tests/__snapshots__/test_converter/test_converter_inline[def-with-args].html
@@ -1,0 +1,1 @@
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline"><mrow><mrow><mi mathvariant="bold">x</mi></mrow></mrow></math>

--- a/tests/__snapshots__/test_converter/test_converter_inline[newcommand-escaped-hash].html
+++ b/tests/__snapshots__/test_converter/test_converter_inline[newcommand-escaped-hash].html
@@ -1,0 +1,1 @@
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline"><mrow><mi>#</mi><mi>#</mi><mi>x</mi></mrow></math>

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,6 +1,6 @@
 import pytest
 
-from latex2mathml.converter import convert, convert_to_element
+from latex2mathml.converter import Converter, convert, convert_to_element
 from latex2mathml.exceptions import DoubleSubscriptsError, DoubleSuperscriptsError
 
 
@@ -404,6 +404,39 @@ def test_double_superscripts_raises(latex: str) -> None:
 def test_double_subscripts_raises() -> None:
     with pytest.raises(DoubleSubscriptsError):
         convert("f_a_b")
+
+
+def test_declare_math_operator() -> None:
+    assert convert(r"\DeclareMathOperator{\Res}{Res} \Res_{z=0}", display="block") == convert(
+        r"\operatorname{Res}_{z=0}", display="block"
+    )
+
+
+def test_newcommand_no_args() -> None:
+    assert convert(r"\newcommand{\R}{\mathbb{R}} \R", display="block") == convert(r"\mathbb{R}", display="block")
+
+
+def test_newcommand_with_args() -> None:
+    assert convert(r"\newcommand{\norm}[1]{\left\|#1\right\|} \norm{x}", display="block") == convert(
+        r"\left\|x\right\|", display="block"
+    )
+
+
+def test_def_command() -> None:
+    assert convert(r"\def\R{\mathbb{R}} \R", display="block") == convert(r"\mathbb{R}", display="block")
+
+
+def test_reusable_macro() -> None:
+    c = Converter(display="block")
+    c.convert(r"\newcommand{\R}{\mathbb{R}}")
+    assert c.convert(r"\R") == convert(r"\mathbb{R}", display="block")
+
+
+def test_newenvironment() -> None:
+    assert convert(
+        r"\newenvironment{myenv}{\begin{bmatrix}}{\end{bmatrix}} \begin{myenv} 1 & 2 \\ 3 & 4 \end{myenv}",
+        display="block",
+    ) == convert(r"\begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix}", display="block")
 
 
 def test_convert_to_element(snapshot: str) -> None:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,7 +1,7 @@
 import pytest
 
 from latex2mathml.converter import Converter, convert, convert_to_element
-from latex2mathml.exceptions import DoubleSubscriptsError, DoubleSuperscriptsError
+from latex2mathml.exceptions import DoubleSubscriptsError, DoubleSuperscriptsError, MissingEndError
 
 
 @pytest.mark.parametrize(
@@ -367,9 +367,16 @@ from latex2mathml.exceptions import DoubleSubscriptsError, DoubleSuperscriptsErr
         pytest.param(r"\shoveleft{x}", id="shoveleft"),
         pytest.param(r"\raise{3pt}{x}", id="raise"),
         pytest.param(r"\lower{3pt}{x}", id="lower"),
+        pytest.param(r"\moveleft{5pt}{x}", id="moveleft"),
+        pytest.param(r"\moveright{5pt}{x}", id="moveright"),
+        pytest.param(r"\smash[t]{x}", id="smash-top"),
         pytest.param(r"\mathchoice{D}{T}{S}{SS}", id="mathchoice-block"),
         pytest.param(r"\sqrt[\leftroot{2}\uproot{4} 3]{x}", id="leftroot-uproot"),
         pytest.param(r"\eqalign{a &= b \cr c &= d}", id="eqalign"),
+        pytest.param(
+            r"\newenvironment{wrapper}{a +}{+ c} \begin{wrapper} b \end{wrapper}",
+            id="newenvironment-multi-node",
+        ),
     ],
 )
 def test_converter(snapshot: str, latex: str) -> None:
@@ -383,6 +390,8 @@ def test_converter(snapshot: str, latex: str) -> None:
         pytest.param(r"\prod_{0}^{\pi}", id="issue-498-prod"),
         pytest.param(r"\sum_{\substack{1\le i\le n\\ i\ne j}}", id="issue-75-2-rows"),
         pytest.param(r"\mathchoice{D}{T}{S}{SS}", id="mathchoice-inline"),
+        pytest.param(r"\def\bold#1{\mathbf{#1}} \bold{x}", id="def-with-args"),
+        pytest.param(r"\newcommand{\foo}[1]{## #1} \foo{x}", id="newcommand-escaped-hash"),
     ],
 )
 def test_converter_inline(snapshot: str, latex: str) -> None:
@@ -390,53 +399,97 @@ def test_converter_inline(snapshot: str, latex: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "latex",
+    ("latex", "exception"),
     [
-        "f^a^b",
-        "f''^2",
+        pytest.param("f^a^b", DoubleSuperscriptsError, id="double-superscript"),
+        pytest.param("f''^2", DoubleSuperscriptsError, id="double-superscript-prime"),
+        pytest.param("f_a_b", DoubleSubscriptsError, id="double-subscript"),
+        pytest.param(
+            r"\newenvironment{myenv}{\begin{bmatrix}}{\end{bmatrix}} \begin{myenv} 1 & 2",
+            MissingEndError,
+            id="newenvironment-missing-end",
+        ),
+        pytest.param(r"\def\A{\A} \A", RecursionError, id="macro-recursion-depth"),
     ],
 )
-def test_double_superscripts_raises(latex: str) -> None:
-    with pytest.raises(DoubleSuperscriptsError):
+def test_converter_raises(latex: str, exception: type[BaseException]) -> None:
+    with pytest.raises(exception):
         convert(latex)
 
 
-def test_double_subscripts_raises() -> None:
-    with pytest.raises(DoubleSubscriptsError):
-        convert("f_a_b")
-
-
-def test_declare_math_operator() -> None:
-    assert convert(r"\DeclareMathOperator{\Res}{Res} \Res_{z=0}", display="block") == convert(
-        r"\operatorname{Res}_{z=0}", display="block"
-    )
-
-
-def test_newcommand_no_args() -> None:
-    assert convert(r"\newcommand{\R}{\mathbb{R}} \R", display="block") == convert(r"\mathbb{R}", display="block")
-
-
-def test_newcommand_with_args() -> None:
-    assert convert(r"\newcommand{\norm}[1]{\left\|#1\right\|} \norm{x}", display="block") == convert(
-        r"\left\|x\right\|", display="block"
-    )
-
-
-def test_def_command() -> None:
-    assert convert(r"\def\R{\mathbb{R}} \R", display="block") == convert(r"\mathbb{R}", display="block")
+@pytest.mark.parametrize(
+    ("latex", "expected", "display"),
+    [
+        pytest.param(
+            r"\DeclareMathOperator{\Res}{Res} \Res_{z=0}",
+            r"\operatorname{Res}_{z=0}",
+            "block",
+            id="declare-math-operator",
+        ),
+        pytest.param(
+            r"\newcommand{\R}{\mathbb{R}} \R",
+            r"\mathbb{R}",
+            "block",
+            id="newcommand-no-args",
+        ),
+        pytest.param(
+            r"\newcommand{\norm}[1]{\left\|#1\right\|} \norm{x}",
+            r"\left\|x\right\|",
+            "block",
+            id="newcommand-with-args",
+        ),
+        pytest.param(
+            r"\newcommand{\greeting}[1][Hello]{#1} \greeting{world}",
+            r"world",
+            "inline",
+            id="newcommand-optional-default",
+        ),
+        pytest.param(
+            r"\newcommand{\myfrac}{\frac} \myfrac{a}{b}",
+            r"\frac{a}{b}",
+            "inline",
+            id="newcommand-expands-to-command",
+        ),
+        pytest.param(
+            r"\newcommand{\nothing}{} \nothing x",
+            r"x",
+            "inline",
+            id="newcommand-empty-body",
+        ),
+        pytest.param(
+            r"\def\R{\mathbb{R}} \R",
+            r"\mathbb{R}",
+            "block",
+            id="def-command",
+        ),
+        pytest.param(
+            r"\newenvironment{myenv}{\begin{bmatrix}}{\end{bmatrix}} \begin{myenv} 1 & 2 \\ 3 & 4 \end{myenv}",
+            r"\begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix}",
+            "block",
+            id="newenvironment",
+        ),
+        pytest.param(
+            r"\newenvironment{paren}[1]{\left( #1 +}{\right)} \begin{paren}{x} y \end{paren}",
+            r"\left( x + y \right)",
+            "block",
+            id="newenvironment-with-args",
+        ),
+        pytest.param(
+            r"\newcommand\R{\mathbb{R}} \R",
+            r"\mathbb{R}",
+            "block",
+            id="newcommand-bare-name",
+        ),
+    ],
+)
+def test_macro(latex: str, expected: str, display: str) -> None:
+    assert convert(latex, display=display) == convert(expected, display=display)
 
 
 def test_reusable_macro() -> None:
     c = Converter(display="block")
     c.convert(r"\newcommand{\R}{\mathbb{R}}")
     assert c.convert(r"\R") == convert(r"\mathbb{R}", display="block")
-
-
-def test_newenvironment() -> None:
-    assert convert(
-        r"\newenvironment{myenv}{\begin{bmatrix}}{\end{bmatrix}} \begin{myenv} 1 & 2 \\ 3 & 4 \end{myenv}",
-        display="block",
-    ) == convert(r"\begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix}", display="block")
 
 
 def test_convert_to_element(snapshot: str) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -188,7 +188,7 @@ wheels = [
 
 [[package]]
 name = "latex2mathml"
-version = "3.80.0"
+version = "3.81.0a1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Resolves #115 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime support for LaTeX macros/environments: \newcommand, \def, \DeclareMathOperator, \newenvironment, and \operatorname*.
  * Stateful Converter instance that preserves macros across conversions.

* **Behavior Changes**
  * Improved token/number/unit parsing and operator recognition.
  * Updated matrix rendering, delimiter/spacing, and environment/macro expansion behavior.

* **Tests**
  * Added tests for macro/environment expansion and stateful Converter behavior.

* **Chores**
  * Bumped package version to 3.81.0a1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->